### PR TITLE
Add (out-of-spec) support for JSONPath in fieldmappings

### DIFF
--- a/evaluator/fieldmappings_test.go
+++ b/evaluator/fieldmappings_test.go
@@ -84,3 +84,35 @@ func TestRuleEvaluator_HandlesJSONPathFieldMappings(t *testing.T) {
 		t.Error("If a fieldmapping is a JSONPath expression, the nested field should be matched")
 	}
 }
+
+func TestRuleEvaluator_HandlesJSONPathByteSlice(t *testing.T) {
+	rule := ForRule(sigma.Rule{
+		Logsource: sigma.Logsource{
+			Category: "category",
+			Product:  "product",
+			Service:  "service",
+		},
+		Detection: sigma.Detection{
+			Searches: map[string]sigma.Search{
+				"test": {
+					FieldMatchers: []sigma.FieldMatcher{{
+						Field:  "name",
+						Values: []string{"value"},
+					}},
+				},
+			},
+			Conditions: []sigma.Condition{
+				{Search: sigma.SearchIdentifier{Name: "test"}}},
+		},
+	}, WithConfig(sigma.Config{
+		FieldMappings: map[string]sigma.FieldMapping{
+			"name": {TargetNames: []string{"$.mapped.name"}},
+		},
+	}))
+
+	if !rule.Matches(context.Background(), map[string]interface{}{
+		"mapped": `{"name": "value"}`,
+	}) {
+		t.Error("If a JSONPath expression encounters a string, the string should be parsed and then matched")
+	}
+}

--- a/evaluator/fieldmappings_test.go
+++ b/evaluator/fieldmappings_test.go
@@ -44,3 +44,43 @@ func TestRuleEvaluator_HandlesBasicFieldMappings(t *testing.T) {
 		t.Error("If a field is mapped, the mapped name should work")
 	}
 }
+
+func TestRuleEvaluator_HandlesJSONPathFieldMappings(t *testing.T) {
+	rule := ForRule(sigma.Rule{
+		Logsource: sigma.Logsource{
+			Category: "category",
+			Product:  "product",
+			Service:  "service",
+		},
+		Detection: sigma.Detection{
+			Searches: map[string]sigma.Search{
+				"test": {
+					FieldMatchers: []sigma.FieldMatcher{{
+						Field:  "name",
+						Values: []string{"value"},
+					}},
+				},
+			},
+			Conditions: []sigma.Condition{
+				{Search: sigma.SearchIdentifier{Name: "test"}}},
+		},
+	}, WithConfig(sigma.Config{
+		FieldMappings: map[string]sigma.FieldMapping{
+			"name": {TargetNames: []string{"$.mapped.name"}},
+		},
+	}))
+
+	if rule.Matches(context.Background(), map[string]interface{}{
+		"name": "value",
+	}) {
+		t.Error("If a field is mapped, the old name shouldn't be used")
+	}
+
+	if !rule.Matches(context.Background(), map[string]interface{}{
+		"mapped": map[string]interface{}{
+			"name": "value",
+		},
+	}) {
+		t.Error("If a fieldmapping is a JSONPath expression, the nested field should be matched")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/bradleyjkemp/sigma-go
 go 1.15
 
 require (
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/alecthomas/participle v0.6.0
 	github.com/bradleyjkemp/cupaloy/v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,8 @@
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/alecthomas/participle v0.6.0 h1:Pvo8XUCQKgIywVjz/+Ci3IsjGg+g/TdKkMcfgghKCEw=
 github.com/alecthomas/participle v0.6.0/go.mod h1:HfdmEuwvr12HXQN44HPWXR0lHmVolVYe4dyL6lQ3duY=
 github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=


### PR DESCRIPTION
With this change, you can now specify a fieldmapping in config like:
```yaml
fieldmappings:
  sigma_fieldname: $.payload.fieldname   # JSONPath mapping
```
Which maps "sigma_fieldname" to a nested event field
```json
{
  "payload": {
    "fieldname": "value"
  }
}
```
This is useful for matching events that aren't just a straight flat map of keys to values.