### PR TITLE
Add InferFileType helper function

### DIFF
--- a/rule_or_config.go
+++ b/rule_or_config.go
@@ -1,0 +1,35 @@
+package sigma
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+func InferFileType(contents []byte) FileType {
+	var fileType FileType
+	yaml.Unmarshal(contents, &fileType)
+	return fileType
+}
+
+type FileType string
+
+const (
+	UnknownFile FileType = ""
+	RuleFile    FileType = "rule"
+	ConfigFile  FileType = "config"
+)
+
+func (f *FileType) UnmarshalYAML(node *yaml.Node) error {
+	// Check if there's a key called "detection".
+	// This is a required field in a Sigma rule but doesn't exist in a config
+	for _, node := range node.Content {
+		if node.Kind == yaml.ScalarNode && node.Value == "detection" {
+			*f = RuleFile
+			return nil
+		}
+		if node.Kind == yaml.ScalarNode && node.Value == "logsources" {
+			*f = ConfigFile
+			return nil
+		}
+	}
+	return nil
+}

--- a/rule_or_config_test.go
+++ b/rule_or_config_test.go
@@ -1,0 +1,44 @@
+package sigma
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Test_isSigmaRule(t *testing.T) {
+	tests := []struct {
+		file         string
+		expectedType FileType
+	}{
+		{
+			`title: foo
+logsources:
+  foo:
+    category: process_creation
+    index: bar
+`,
+			ConfigFile,
+		},
+		{
+			`title: foo
+detection:
+    foo:
+        - bar
+        - baz
+    selection: foo
+`,
+			RuleFile,
+		},
+	}
+	for _, tt := range tests {
+		var fileType FileType
+		err := yaml.Unmarshal([]byte(tt.file), &fileType)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fileType != tt.expectedType {
+			t.Errorf("Expected\n%s to be detected as a rule", tt.file)
+		}
+	}
+}


### PR DESCRIPTION
This is a helper function I've found necessary in both `sigmafmt` and `sigma-test`. Makes sense to keep this inference logic in one place.