### PR TITLE
Fix aggregations where the threshold is 0

### DIFF
--- a/condition_parser.go
+++ b/condition_parser.go
@@ -12,7 +12,7 @@ var (
 		`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+\*[a-zA-Z0-9_*]*)` +
 		`|(?P<SearchIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)` +
 		`|(?P<ComparisonOperation>=|!=|<|<=|>|>=)` +
-		`|(?P<ComparisonValue>[1-9][0-9]*)` +
+		`|(?P<ComparisonValue>[0-9][0-9]*)` +
 		`|(?P<Pipe>[|])` +
 		`|(\s+)`,
 	))

--- a/condition_parser.go
+++ b/condition_parser.go
@@ -12,7 +12,7 @@ var (
 		`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+\*[a-zA-Z0-9_*]*)` +
 		`|(?P<SearchIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)` +
 		`|(?P<ComparisonOperation>=|!=|<|<=|>|>=)` +
-		`|(?P<ComparisonValue>[0-9][0-9]*)` +
+		`|(?P<ComparisonValue>[0-9]+)` +
 		`|(?P<Pipe>[|])` +
 		`|(\s+)`,
 	))

--- a/condition_parser.go
+++ b/condition_parser.go
@@ -12,7 +12,7 @@ var (
 		`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+\*[a-zA-Z0-9_*]*)` +
 		`|(?P<SearchIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)` +
 		`|(?P<ComparisonOperation>=|!=|<|<=|>|>=)` +
-		`|(?P<ComparisonValue>[0-9]+)` +
+		`|(?P<ComparisonValue>0|[1-9][0-9]*)` +
 		`|(?P<Pipe>[|])` +
 		`|(\s+)`,
 	))

--- a/condition_parser_test.go
+++ b/condition_parser_test.go
@@ -15,6 +15,7 @@ func TestParseCondition(t *testing.T) {
 		{"a and b or c", Condition{Search: Or{And{SearchIdentifier{"a"}, SearchIdentifier{"b"}}, SearchIdentifier{"c"}}}},
 		{"a or b and c", Condition{Search: Or{SearchIdentifier{"a"}, And{SearchIdentifier{"b"}, SearchIdentifier{"c"}}}}},
 		{"a and b and c", Condition{Search: And{SearchIdentifier{"a"}, SearchIdentifier{"b"}, SearchIdentifier{"c"}}}},
+		{"a | count(b) > 0", Condition{Search: SearchIdentifier{"a"}, Aggregation: Comparison{Func: Count{Field: "b"}, Op: GreaterThan, Threshold: 0}}},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
The regex for `<ComparisonValue>` didn't allow leading zeros (in an attempt at normalisation i.e. not allowing `1` and `01` representing the same thing)

Unfortunately this was overly strict and excluded 0 itself.