### PR TITLE
Fix aggregations using <= and >= operators

### DIFF
--- a/condition_parser.go
+++ b/condition_parser.go
@@ -11,7 +11,7 @@ var (
 		`|(?P<Operator>(?i)and|or|not|[()])` +
 		`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+\*[a-zA-Z0-9_*]*)` +
 		`|(?P<SearchIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)` +
-		`|(?P<ComparisonOperation>=|!=|<|<=|>|>=)` +
+		`|(?P<ComparisonOperation>=|!=|<=|>=|<|>)` +
 		`|(?P<ComparisonValue>0|[1-9][0-9]*)` +
 		`|(?P<Pipe>[|])` +
 		`|(\s+)`,

--- a/condition_parser_test.go
+++ b/condition_parser_test.go
@@ -16,6 +16,7 @@ func TestParseCondition(t *testing.T) {
 		{"a or b and c", Condition{Search: Or{SearchIdentifier{"a"}, And{SearchIdentifier{"b"}, SearchIdentifier{"c"}}}}},
 		{"a and b and c", Condition{Search: And{SearchIdentifier{"a"}, SearchIdentifier{"b"}, SearchIdentifier{"c"}}}},
 		{"a | count(b) > 0", Condition{Search: SearchIdentifier{"a"}, Aggregation: Comparison{Func: Count{Field: "b"}, Op: GreaterThan, Threshold: 0}}},
+		{"a | count(b) >= 0", Condition{Search: SearchIdentifier{"a"}, Aggregation: Comparison{Func: Count{Field: "b"}, Op: GreaterThanEqual, Threshold: 0}}},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
The priority order of the `<ComparisonOperation>` regex meant that the operator `<=` would be matched as just `<` and then `=` attempt to be parsed as the threshold value.

Re-ordered the cases to eliminate this ambiguity