### PR TITLE
Add Nested Field support to Sigma Evaluations

### DIFF
--- a/evaluator/evaluate_search.go
+++ b/evaluator/evaluate_search.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -158,13 +159,16 @@ func (rule *RuleEvaluator) GetFieldValuesFromEvent(field string, event Event) []
 	} else {
 		// FieldMapping does exist so check each of the possible mapped names instead of the name from the rule
 		for _, mapping := range rule.fieldmappings[field] {
-			if strings.HasPrefix(mapping, "$.") || strings.HasPrefix(mapping, "$[") {
-				// This is a jsonpath expression
-				actualValues = append(actualValues, evaluateJSONPath(mapping, event))
-			} else {
-				// This is just a field name
-				actualValues = append(actualValues, eventValue(event, mapping))
+			var v interface{}
+
+			switch {
+			case strings.HasPrefix(mapping, "$.") || strings.HasPrefix(mapping, "$["):
+				v = evaluateJSONPath(mapping, event)
+			default:
+				v = eventValue(event, mapping)
 			}
+
+			actualValues = append(actualValues, toGenericSlice(v)...)
 		}
 	}
 	return actualValues
@@ -269,4 +273,21 @@ var modifiers = map[string]valueModifier{
 			return next(actual, base64.StdEncoding.EncodeToString([]byte(expected)))
 		}
 	},
+}
+
+func toGenericSlice(v interface{}) []interface{} {
+	rv := reflect.ValueOf(v)
+
+	// if this isn't a slice, then return a slice containing the
+	// original value
+	if rv.Kind() != reflect.Slice {
+		return []interface{}{v}
+	}
+
+	var out []interface{}
+	for i := 0; i < rv.Len(); i++ {
+		out = append(out, rv.Index(i).Interface())
+	}
+
+	return out
 }


### PR DESCRIPTION
This PR adds Nested Field support to Sigma Evaluations, allowing for fields nested objects to be evaluated as part of a Sigma rule. 

Caveats: 

- Evaluations are not scoped to nested objects - for example, the following will match: 

```
   UserType: customer
   UserID: user_xxxxxxxxx
```

```
   "users" : [
      {
         "user_type":"customer",
         "user_id": "user_yyyyyyyyy"
      },
      {
         "user_type":"staff",
         "user_id": "user_xxxxxxxxx"
      },
   ]
```