### PR TITLE
Support lists of maps in detections

### DIFF
--- a/evaluator/evaluate_test.go
+++ b/evaluator/evaluate_test.go
@@ -12,41 +12,49 @@ func TestRuleEvaluator_Matches(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"foo": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field: "foo-field",
-							Values: []string{
-								"foo-value",
+							{
+								Field: "foo-field",
+								Values: []string{
+									"foo-value",
+								},
 							},
 						},
 					},
 				},
 				"bar": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field: "bar-field",
-							Values: []string{
-								"bar-value",
+							{
+								Field: "bar-field",
+								Values: []string{
+									"bar-value",
+								},
 							},
 						},
 					},
 				},
 				"baz": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field: "baz-field",
-							Values: []string{
-								"baz-value",
+							{
+								Field: "baz-field",
+								Values: []string{
+									"baz-value",
+								},
 							},
 						},
 					},
 				},
 				"null-field": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field: "non-existent-field",
-							Values: []string{
-								"null",
+							{
+								Field: "non-existent-field",
+								Values: []string{
+									"null",
+								},
 							},
 						},
 					},
@@ -89,11 +97,13 @@ func TestRuleEvaluator_Matches_WithPlaceholder(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"foo": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field: "foo-field",
-							Values: []string{
-								"%foo-placeholder%",
+							{
+								Field: "foo-field",
+								Values: []string{
+									"%foo-placeholder%",
+								},
 							},
 						},
 					},
@@ -132,12 +142,14 @@ func TestRuleEvaluator_Matches_Regex(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"foo": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field:     "foo-field",
-							Modifiers: []string{"re"},
-							Values: []string{
-								"foo.*baz",
+							{
+								Field:     "foo-field",
+								Modifiers: []string{"re"},
+								Values: []string{
+									"foo.*baz",
+								},
 							},
 						},
 					},
@@ -170,12 +182,14 @@ func TestRuleEvaluator_Matches_CIDR(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"foo": {
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field:     "foo-field",
-							Modifiers: []string{"cidr"},
-							Values: []string{
-								"10.0.0.0/8",
+							{
+								Field:     "foo-field",
+								Modifiers: []string{"cidr"},
+								Values: []string{
+									"10.0.0.0/8",
+								},
 							},
 						},
 					},

--- a/evaluator/fieldmappings_test.go
+++ b/evaluator/fieldmappings_test.go
@@ -17,10 +17,12 @@ func TestRuleEvaluator_HandlesBasicFieldMappings(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"test": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "name",
-						Values: []string{"value"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "name",
+							Values: []string{"value"},
+						}},
+					},
 				},
 			},
 			Conditions: []sigma.Condition{
@@ -55,10 +57,12 @@ func TestRuleEvaluator_HandlesJSONPathFieldMappings(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"test": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "name",
-						Values: []string{"value"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "name",
+							Values: []string{"value"},
+						}},
+					},
 				},
 			},
 			Conditions: []sigma.Condition{
@@ -97,10 +101,12 @@ func TestRuleEvaluator_HandlesJSONPathByteSlice(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"test": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "name",
-						Values: []string{"value"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "name",
+							Values: []string{"value"},
+						}},
+					},
 				},
 			},
 			Conditions: []sigma.Condition{
@@ -130,10 +136,12 @@ func TestRuleEvaluator_HandlesToplevelJSONPath(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"test": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "name",
-						Values: []string{"value"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "name",
+							Values: []string{"value"},
+						}},
+					},
 				},
 			},
 			Conditions: []sigma.Condition{
@@ -163,10 +171,12 @@ func TestRuleEvaluator_GetFieldValuesFromEvent(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"test": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "name",
-						Values: []string{"value"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "name",
+							Values: []string{"value"},
+						}},
+					},
 				},
 			},
 			Conditions: []sigma.Condition{
@@ -205,16 +215,20 @@ func TestRuleEvaluator_HandlesToplevelNestedJSONPath(t *testing.T) {
 		Detection: sigma.Detection{
 			Searches: map[string]sigma.Search{
 				"test": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "name",
-						Values: []string{"value1"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "name",
+							Values: []string{"value1"},
+						}},
+					},
 				},
 				"field2": {
-					FieldMatchers: []sigma.FieldMatcher{{
-						Field:  "field2",
-						Values: []string{"hello"},
-					}},
+					EventMatchers: []sigma.EventMatcher{
+						{{
+							Field:  "field2",
+							Values: []string{"hello"},
+						}},
+					},
 				},
 			},
 			Conditions: []sigma.Condition{

--- a/evaluator/index_test.go
+++ b/evaluator/index_test.go
@@ -88,10 +88,12 @@ func TestRuleEvaluator_ReleventToEvent_LogsourceConditions(t *testing.T) {
 					Product:  "product",
 				},
 				Conditions: sigma.Search{
-					FieldMatchers: []sigma.FieldMatcher{
+					EventMatchers: []sigma.EventMatcher{
 						{
-							Field:  "foo",
-							Values: []string{"bar"},
+							{
+								Field:  "foo",
+								Values: []string{"bar"},
+							},
 						},
 					},
 				},

--- a/testdata/TestParseConfig-sysmon
+++ b/testdata/TestParseConfig-sysmon
@@ -14,13 +14,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=2) "22"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=2) "22"
+              }
             }
           }
         }
@@ -42,13 +44,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=1) "6"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=1) "6"
+              }
             }
           }
         }
@@ -70,13 +74,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=2) "11"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=2) "11"
+              }
             }
           }
         }
@@ -98,13 +104,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=1) "7"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=1) "7"
+              }
             }
           }
         }
@@ -126,13 +134,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=1) "3"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=1) "3"
+              }
             }
           }
         }
@@ -154,13 +164,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=2) "10"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=2) "10"
+              }
             }
           }
         }
@@ -182,13 +194,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=1) "1"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=1) "1"
+              }
             }
           }
         }
@@ -210,13 +224,15 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=1) "5"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=1) "5"
+              }
             }
           }
         }
@@ -238,15 +254,17 @@
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=1) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=7) "EventID",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=3) {
-              (string) (len=2) "12",
-              (string) (len=2) "13",
-              (string) (len=2) "14"
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=7) "EventID",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=3) {
+                (string) (len=2) "12",
+                (string) (len=2) "13",
+                (string) (len=2) "14"
+              }
             }
           }
         }

--- a/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
+++ b/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
@@ -1,0 +1,154 @@
+(sigma.Rule) {
+  Title: (string) (len=15) "Chafer Activity",
+  Logsource: (sigma.Logsource) {
+    Category: (string) (len=16) "process_creation",
+    Product: (string) (len=7) "windows",
+    Service: (string) "",
+    Definition: (string) ""
+  },
+  Detection: (sigma.Detection) {
+    Searches: (map[string]sigma.Search) (len=4) {
+      (string) (len=18) "selection_process0": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=12) "\\Service.exe"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=2) {
+                (string) (len=1) "i",
+                (string) (len=1) "u"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=18) "selection_process1": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=2) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=30) "\\microsoft\\Taskbar\\autoit3.exe"
+              }
+            }
+          },
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=10) "startswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=10) "C:\\wsc.exe"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=18) "selection_process2": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=17) "\\Windows\\Temp\\DB\\"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=4) ".exe"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=18) "selection_process3": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]string) (len=2) {
+                (string) (len=13) "\\nslookup.exe",
+                (string) (len=6) "-q=TXT"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "ParentImage",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=7) "\\Autoit"
+              }
+            }
+          }
+        }
+      }
+    },
+    Conditions: (sigma.Conditions) (len=1) {
+      (sigma.Condition) {
+        Search: (sigma.OneOfPattern) {
+          Pattern: (string) (len=10) "selection*"
+        },
+        Aggregation: (sigma.AggregationExpr) <nil>
+      }
+    },
+    Timeframe: (time.Duration) 0s
+  },
+  ID: (string) (len=36) "ce6e34ca-966d-41c9-8d93-5b06c8b97a06",
+  Related: ([]string) <nil>,
+  Status: (string) (len=4) "test",
+  Description: (string) (len=88) "Detects Chafer activity attributed to OilRig as reported in Nyotron report in March 2018",
+  Author: (string) (len=82) "Florian Roth, Markus Neis, Jonhnathan Ribeiro, Daniil Yugoslavskiy, oscd.community",
+  Level: (string) (len=4) "high",
+  References: ([]string) (len=1) {
+    (string) (len=69) "https://nyotron.com/nyotron-discovers-next-generation-oilrig-attacks/"
+  },
+  Tags: ([]string) (len=9) {
+    (string) (len=18) "attack.persistence",
+    (string) (len=12) "attack.g0049",
+    (string) (len=16) "attack.t1053.005",
+    (string) (len=12) "attack.s0111",
+    (string) (len=16) "attack.t1543.003",
+    (string) (len=22) "attack.defense_evasion",
+    (string) (len=12) "attack.t1112",
+    (string) (len=26) "attack.command_and_control",
+    (string) (len=16) "attack.t1071.004"
+  },
+  AdditionalFields: (map[string]interface {}) (len=3) {
+    (string) (len=4) "date": (string) (len=10) "2018/03/23",
+    (string) (len=14) "falsepositives": ([]interface {}) (len=1) {
+      (string) (len=7) "Unknown"
+    },
+    (string) (len=8) "modified": (string) (len=10) "2021/09/19"
+  }
+}

--- a/testdata/TestParseRule-proxy_apt40
+++ b/testdata/TestParseRule-proxy_apt40
@@ -10,21 +10,23 @@
     Searches: (map[string]sigma.Search) (len=1) {
       (string) (len=9) "selection": (sigma.Search) {
         Keywords: ([]string) <nil>,
-        FieldMatchers: ([]sigma.FieldMatcher) (len=2) {
-          (sigma.FieldMatcher) {
-            Field: (string) (len=11) "c-useragent",
-            Modifiers: ([]string) {
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "c-useragent",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=109) "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36"
+              }
             },
-            Values: ([]string) (len=1) {
-              (string) (len=109) "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36"
-            }
-          },
-          (sigma.FieldMatcher) {
-            Field: (string) (len=5) "r-dns",
-            Modifiers: ([]string) {
-            },
-            Values: ([]string) (len=1) {
-              (string) (len=15) "api.dropbox.com"
+            (sigma.FieldMatcher) {
+              Field: (string) (len=5) "r-dns",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=15) "api.dropbox.com"
+              }
             }
           }
         }

--- a/testdata/proc_creation_win_apt_chafer_mar18.rule.yml
+++ b/testdata/proc_creation_win_apt_chafer_mar18.rule.yml
@@ -1,0 +1,46 @@
+title: Chafer Activity
+id: ce6e34ca-966d-41c9-8d93-5b06c8b97a06
+#related:
+#  - id: 53ba33fd-3a50-4468-a5ef-c583635cfa92
+#    type: derived
+description: Detects Chafer activity attributed to OilRig as reported in Nyotron report in March 2018
+status: test
+references:
+  - https://nyotron.com/nyotron-discovers-next-generation-oilrig-attacks/
+tags:
+  - attack.persistence
+  - attack.g0049
+  - attack.t1053.005
+  - attack.s0111
+  - attack.t1543.003
+  - attack.defense_evasion
+  - attack.t1112
+  - attack.command_and_control
+  - attack.t1071.004
+date: 2018/03/23
+modified: 2021/09/19
+author: Florian Roth, Markus Neis, Jonhnathan Ribeiro, Daniil Yugoslavskiy, oscd.community
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  selection_process0:
+    CommandLine|contains: '\Service.exe'
+    CommandLine|endswith:
+      - 'i'
+      - 'u'
+  selection_process1:
+    - CommandLine|endswith: '\microsoft\Taskbar\autoit3.exe'
+    - CommandLine|startswith: 'C:\wsc.exe'
+  selection_process2:
+    Image|contains: '\Windows\Temp\DB\'
+    Image|endswith: '.exe'
+  selection_process3:
+    CommandLine|contains|all:
+      - '\nslookup.exe'
+      - '-q=TXT'
+    ParentImage|contains: '\Autoit'
+  condition: 1 of selection*
+falsepositives:
+  - Unknown
+level: high


### PR DESCRIPTION
Previously we assumed that a detection was either:
* A list of keywords (strings)
* A map from field name (+ modifier) to value

It turns out that there's a third possibility: lists of maps (implicitly ORed)

This PR extends the parser and evaluator to support this (with the default case being a list of a single map)

Closes #9 