### PR TITLE
Add `AdditionalFields` to `Logsource`

### DIFF
--- a/rule_parser.go
+++ b/rule_parser.go
@@ -33,8 +33,8 @@ type Logsource struct {
 	Service    string
 	Definition string
 
-  // Any non-standard fields will end up in here
-  AdditionalFields map[string]interface{} `yaml:",inline"`
+	// Any non-standard fields will end up in here
+	AditionalFields map[string]interface{} `yaml:",inline"`
 }
 
 type Detection struct {

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -34,7 +34,7 @@ type Logsource struct {
 	Definition string
 
 	// Any non-standard fields will end up in here
-	AditionalFields map[string]interface{} `yaml:",inline"`
+	AdditionalFields map[string]interface{} `yaml:",inline"`
 }
 
 type Detection struct {

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -32,6 +32,9 @@ type Logsource struct {
 	Product    string
 	Service    string
 	Definition string
+
+  // Any non-standard fields will end up in here
+  AdditionalFields map[string]interface{} `yaml:",inline"`
 }
 
 type Detection struct {

--- a/testdata/TestParseConfig-sysmon
+++ b/testdata/TestParseConfig-sysmon
@@ -9,7 +9,8 @@
         Category: (string) (len=9) "dns_query",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -31,7 +32,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=13) "driver_loaded": (sigma.LogsourceMapping) {
@@ -39,7 +41,8 @@
         Category: (string) (len=11) "driver_load",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -61,7 +64,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=13) "file_creation": (sigma.LogsourceMapping) {
@@ -69,7 +73,8 @@
         Category: (string) (len=10) "file_event",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -91,7 +96,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=12) "image_loaded": (sigma.LogsourceMapping) {
@@ -99,7 +105,8 @@
         Category: (string) (len=10) "image_load",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -121,7 +128,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=18) "network_connection": (sigma.LogsourceMapping) {
@@ -129,7 +137,8 @@
         Category: (string) (len=18) "network_connection",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -151,7 +160,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=14) "process_access": (sigma.LogsourceMapping) {
@@ -159,7 +169,8 @@
         Category: (string) (len=14) "process_access",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -181,7 +192,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=16) "process_creation": (sigma.LogsourceMapping) {
@@ -189,7 +201,8 @@
         Category: (string) (len=16) "process_creation",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -211,7 +224,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=18) "process_terminated": (sigma.LogsourceMapping) {
@@ -219,7 +233,8 @@
         Category: (string) (len=19) "process_termination",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -241,7 +256,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     },
     (string) (len=14) "registry_event": (sigma.LogsourceMapping) {
@@ -249,7 +265,8 @@
         Category: (string) (len=14) "registry_event",
         Product: (string) (len=7) "windows",
         Service: (string) "",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
@@ -273,7 +290,8 @@
         Category: (string) "",
         Product: (string) (len=7) "windows",
         Service: (string) (len=6) "sysmon",
-        Definition: (string) ""
+        Definition: (string) "",
+        AdditionalFields: (map[string]interface {}) <nil>
       }
     }
   },

--- a/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
+++ b/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
@@ -4,7 +4,8 @@
     Category: (string) (len=16) "process_creation",
     Product: (string) (len=7) "windows",
     Service: (string) "",
-    Definition: (string) ""
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
   },
   Detection: (sigma.Detection) {
     Searches: (map[string]sigma.Search) (len=4) {

--- a/testdata/TestParseRule-proxy_apt40
+++ b/testdata/TestParseRule-proxy_apt40
@@ -4,7 +4,8 @@
     Category: (string) (len=5) "proxy",
     Product: (string) "",
     Service: (string) "",
-    Definition: (string) ""
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
   },
   Detection: (sigma.Detection) {
     Searches: (map[string]sigma.Search) (len=1) {


### PR DESCRIPTION
According to the Sigma specification, a rule's `logsource` field should accept arbitrary additional keys that are not defined the spec similar to how the root `Rule` object itself can contain additional fields of arbitrary type. For reference, the logsource section is [here](https://github.com/SigmaHQ/sigma/wiki/Specification#log-source). It says (emphasis added):

> It consists of [the attributes "category", "product" and "service"] that are evaluated automatically by the converters **and an arbitrary number of optional elements**. We recommend using a "definition" value in cases in which further explication is necessary.

This PR simply adds the `AdditionalFields` member to the `Logsource` struct to allow such rules to be loaded properly.