### PR TITLE
Bug demo

### DIFF
--- a/evaluator/bug_demo_test.go
+++ b/evaluator/bug_demo_test.go
@@ -19,6 +19,30 @@ var logsourceBConfigYml []byte
 //go:embed test_rule.yml
 var testRuleYml []byte
 
+var event = map[string]interface{}{
+	"payload": map[string]interface{}{
+		"something": map[string]interface{}{
+			"user_id": "abc123",
+		},
+	},
+}
+
+// Case where we only load one config
+func TestOnePaths(t *testing.T) {
+	logsourceAConfig, err := sigma.ParseConfig(logsourceAConfigYml)
+	assert.NoError(t, err)
+	testRule, err := sigma.ParseRule(testRuleYml)
+	assert.NoError(t, err)
+
+	ruleEvaluator := ForRule(testRule, WithConfig(logsourceAConfig), WithPlaceholderExpander(placeholderExpander))
+
+	result, err := ruleEvaluator.Matches(context.Background(), event)
+	assert.NoError(t, err)
+	assert.True(t, result.SearchResults["TestCondition"])
+
+}
+
+// Case where we load two configs
 func TestMultipleSamePaths(t *testing.T) {
 	logsourceAConfig, err := sigma.ParseConfig(logsourceAConfigYml)
 	assert.NoError(t, err)
@@ -26,14 +50,6 @@ func TestMultipleSamePaths(t *testing.T) {
 	assert.NoError(t, err)
 	testRule, err := sigma.ParseRule(testRuleYml)
 	assert.NoError(t, err)
-
-	event := map[string]interface{}{
-		"payload": map[string]interface{}{
-			"something": map[string]interface{}{
-				"user_id": "abc123",
-			},
-		},
-	}
 
 	ruleEvaluator := ForRule(testRule, WithConfig(logsourceAConfig, logsourceBConfig), WithPlaceholderExpander(placeholderExpander))
 

--- a/evaluator/bug_demo_test.go
+++ b/evaluator/bug_demo_test.go
@@ -57,6 +57,19 @@ func TestMultipleSamePaths(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result.SearchResults["TestCondition"])
 
+	// Now check for other path
+	otherEvent := map[string]interface{}{
+		"payload": map[string]interface{}{
+			"other": map[string]interface{}{
+				"user_id": "abc123",
+			},
+		},
+	}
+
+	result, err = ruleEvaluator.Matches(context.Background(), otherEvent)
+	assert.NoError(t, err)
+	assert.False(t, result.SearchResults["TestCondition"])
+
 }
 
 func placeholderExpander(ctx context.Context, placeholderName string) ([]string, error) {

--- a/evaluator/bug_demo_test.go
+++ b/evaluator/bug_demo_test.go
@@ -11,18 +11,18 @@ import (
 )
 
 //go:embed logsource_a.config.yml
-var vpnConfigYml []byte
+var logsourceAConfigYml []byte
 
 //go:embed logsource_b.config.yml
-var apiConfigYml []byte
+var logsourceBConfigYml []byte
 
 //go:embed test_rule.yml
 var testRuleYml []byte
 
 func TestMultipleSamePaths(t *testing.T) {
-	vpnConfig, err := sigma.ParseConfig(vpnConfigYml)
+	logsourceAConfig, err := sigma.ParseConfig(logsourceAConfigYml)
 	assert.NoError(t, err)
-	apiConfig, err := sigma.ParseConfig(apiConfigYml)
+	logsourceBConfig, err := sigma.ParseConfig(logsourceBConfigYml)
 	assert.NoError(t, err)
 	testRule, err := sigma.ParseRule(testRuleYml)
 	assert.NoError(t, err)
@@ -35,7 +35,7 @@ func TestMultipleSamePaths(t *testing.T) {
 		},
 	}
 
-	ruleEvaluator := ForRule(testRule, WithConfig(vpnConfig, apiConfig), WithPlaceholderExpander(placeholderExpander))
+	ruleEvaluator := ForRule(testRule, WithConfig(logsourceAConfig, logsourceBConfig), WithPlaceholderExpander(placeholderExpander))
 
 	result, err := ruleEvaluator.Matches(context.Background(), event)
 	assert.NoError(t, err)

--- a/evaluator/evaluate_search_test.go
+++ b/evaluator/evaluate_search_test.go
@@ -1,0 +1,48 @@
+package evaluator
+
+import (
+	"context"
+	"testing"
+
+	_ "embed"
+
+	"github.com/bradleyjkemp/sigma-go"
+	"github.com/stretchr/testify/assert"
+)
+
+//go:embed logsource_a.config.yml
+var vpnConfigYml []byte
+
+//go:embed logsource_b.config.yml
+var apiConfigYml []byte
+
+//go:embed test_rule.yml
+var testRuleYml []byte
+
+func TestMultipleSamePaths(t *testing.T) {
+	vpnConfig, err := sigma.ParseConfig(vpnConfigYml)
+	assert.NoError(t, err)
+	apiConfig, err := sigma.ParseConfig(apiConfigYml)
+	assert.NoError(t, err)
+	testRule, err := sigma.ParseRule(testRuleYml)
+	assert.NoError(t, err)
+
+	event := map[string]interface{}{
+		"payload": map[string]interface{}{
+			"something": map[string]interface{}{
+				"user_id": "abc123",
+			},
+		},
+	}
+
+	ruleEvaluator := ForRule(testRule, WithConfig(vpnConfig, apiConfig), WithPlaceholderExpander(placeholderExpander))
+
+	result, err := ruleEvaluator.Matches(context.Background(), event)
+	assert.NoError(t, err)
+	assert.False(t, result.SearchResults["TestCondition"])
+
+}
+
+func placeholderExpander(ctx context.Context, placeholderName string) ([]string, error) {
+	return nil, nil
+}

--- a/evaluator/logsource_a.config.yml
+++ b/evaluator/logsource_a.config.yml
@@ -1,0 +1,12 @@
+title: Logsource A
+backends:
+  - github.com/bradleyjkemp/sigma-go
+logsources:
+  log-source-a:
+    category: logsource-a
+    product: logsource-a
+    index: logsource-a
+
+fieldmappings:
+  Source: $.source
+  UserID: $.payload.something.user_id

--- a/evaluator/logsource_b.config.yml
+++ b/evaluator/logsource_b.config.yml
@@ -1,0 +1,10 @@
+title: Logsource B
+backends:
+  - github.com/bradleyjkemp/sigma-go
+logsources:
+  log-source-b:
+    category: logsource-b
+    product: logsource-b
+    index: logsource-b
+fieldmappings:
+  UserID: $.payload.other.user_id

--- a/evaluator/test_rule.yml
+++ b/evaluator/test_rule.yml
@@ -1,0 +1,12 @@
+title: Test Rule
+description: "Rule for testing"
+
+logsource:
+    category: logsource-a
+    product: logsource-a
+detection:
+    TestCondition:
+        UserID: abc123
+    condition: TestCondition
+
+id: abc-123

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bradleyjkemp/sigma-go
 
-go 1.15
+go 1.16
 
 require (
 	github.com/PaesslerAG/jsonpath v0.1.1


### PR DESCRIPTION
This PR includes a unit test which demonstrates an issue with the library.

We have two configs from two different logsources, A and B, which both have a mapping to a field `UserID`. We then have a rule, which matches on a certain value of `UserID`.

We have an event that would trigger the rule from one logsource, but the two different mappings from two different mappings causes the rule to fail. It should pass.