### PR TITLE
Parse the Rule's 'related' keyword as slice of maps

### DIFF
--- a/rule_parser.go
+++ b/rule_parser.go
@@ -15,7 +15,7 @@ type Rule struct {
 	Detection Detection
 
 	ID          string
-	Related     []map[string]string
+	Related     []RelatedRule
 	Status      string
 	Description string
 	Author      string
@@ -25,6 +25,11 @@ type Rule struct {
 
 	// Any non-standard fields will end up in here
 	AdditionalFields map[string]interface{} `yaml:",inline"`
+}
+
+type RelatedRule struct {
+	ID   string
+	Type string
 }
 
 type Logsource struct {

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -15,7 +15,7 @@ type Rule struct {
 	Detection Detection
 
 	ID          string
-	Related     []string
+	Related     []map[string]string
 	Status      string
 	Description string
 	Author      string

--- a/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
+++ b/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
@@ -126,7 +126,7 @@
     Timeframe: (time.Duration) 0s
   },
   ID: (string) (len=36) "ce6e34ca-966d-41c9-8d93-5b06c8b97a06",
-  Related: ([]string) <nil>,
+  Related: ([]sigma.RelatedRule) <nil>,
   Status: (string) (len=4) "test",
   Description: (string) (len=88) "Detects Chafer activity attributed to OilRig as reported in Nyotron report in March 2018",
   Author: (string) (len=82) "Florian Roth, Markus Neis, Jonhnathan Ribeiro, Daniil Yugoslavskiy, oscd.community",

--- a/testdata/TestParseRule-proxy_apt40
+++ b/testdata/TestParseRule-proxy_apt40
@@ -44,7 +44,7 @@
     Timeframe: (time.Duration) 0s
   },
   ID: (string) (len=36) "5ba715b6-71b7-44fd-8245-f66893e81b3d",
-  Related: ([]string) <nil>,
+  Related: ([]sigma.RelatedRule) <nil>,
   Status: (string) (len=12) "experimental",
   Description: (string) (len=58) "Detects suspicious user agent string of APT40 Dropbox tool",
   Author: (string) (len=13) "Thomas Patzke",

--- a/testdata/TestParseRule-zeek_smb_converted_win_susp_psexec
+++ b/testdata/TestParseRule-zeek_smb_converted_win_susp_psexec
@@ -1,0 +1,100 @@
+(sigma.Rule) {
+  Title: (string) (len=34) "Suspicious PsExec Execution - Zeek",
+  Logsource: (sigma.Logsource) {
+    Category: (string) "",
+    Product: (string) (len=4) "zeek",
+    Service: (string) (len=9) "smb_files",
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
+  },
+  Detection: (sigma.Detection) {
+    Searches: (map[string]sigma.Search) (len=2) {
+      (string) (len=6) "filter": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=4) "name",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=10) "startswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=8) "PSEXESVC"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=9) "selection": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=4) "path",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]string) (len=2) {
+                (string) (len=2) "\\\\",
+                (string) (len=5) "\\IPC$"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=4) "name",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=3) {
+                (string) (len=6) "-stdin",
+                (string) (len=7) "-stdout",
+                (string) (len=7) "-stderr"
+              }
+            }
+          }
+        }
+      }
+    },
+    Conditions: (sigma.Conditions) (len=1) {
+      (sigma.Condition) {
+        Search: (sigma.And) (len=2) {
+          (sigma.SearchIdentifier) {
+            Name: (string) (len=9) "selection"
+          },
+          (sigma.Not) {
+            Expr: (sigma.SearchIdentifier) {
+              Name: (string) (len=6) "filter"
+            }
+          }
+        },
+        Aggregation: (sigma.AggregationExpr) <nil>
+      }
+    },
+    Timeframe: (time.Duration) 0s
+  },
+  ID: (string) (len=36) "f1b3a22a-45e6-4004-afb5-4291f9c21166",
+  Related: ([]sigma.RelatedRule) (len=1) {
+    (sigma.RelatedRule) {
+      ID: (string) (len=36) "c462f537-a1e3-41a6-b5fc-b2c2cef9bf82",
+      Type: (string) (len=7) "derived"
+    }
+  },
+  Status: (string) (len=4) "test",
+  Description: (string) (len=214) "detects execution of psexec or paexec with renamed service name, this rule helps to filter out the noise if psexec is used for legit purposes or if attacker uses a different psexec client other than sysinternal one",
+  Author: (string) (len=39) "Samir Bousseaden, @neu5ron, Tim Shelton",
+  Level: (string) (len=4) "high",
+  References: ([]string) (len=1) {
+    (string) (len=71) "https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html"
+  },
+  Tags: ([]string) (len=2) {
+    (string) (len=23) "attack.lateral_movement",
+    (string) (len=16) "attack.t1021.002"
+  },
+  AdditionalFields: (map[string]interface {}) (len=3) {
+    (string) (len=4) "date": (string) (len=10) "2020/04/02",
+    (string) (len=14) "falsepositives": ([]interface {}) (len=1) {
+      (string) (len=7) "Unknown"
+    },
+    (string) (len=8) "modified": (string) (len=10) "2022/12/27"
+  }
+}

--- a/testdata/zeek_smb_converted_win_susp_psexec.rule.yml
+++ b/testdata/zeek_smb_converted_win_susp_psexec.rule.yml
@@ -1,0 +1,33 @@
+title: Suspicious PsExec Execution - Zeek
+id: f1b3a22a-45e6-4004-afb5-4291f9c21166
+related:
+  - id: c462f537-a1e3-41a6-b5fc-b2c2cef9bf82
+    type: derived
+status: test
+description: detects execution of psexec or paexec with renamed service name, this rule helps to filter out the noise if psexec is used for legit purposes or if attacker uses a different psexec client other than sysinternal one
+references:
+  - https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html
+author: Samir Bousseaden, @neu5ron, Tim Shelton
+date: 2020/04/02
+modified: 2022/12/27
+tags:
+  - attack.lateral_movement
+  - attack.t1021.002
+logsource:
+  product: zeek
+  service: smb_files
+detection:
+  selection:
+    path|contains|all:
+      - '\\'
+      - '\IPC$'
+    name|endswith:
+      - '-stdin'
+      - '-stdout'
+      - '-stderr'
+  filter:
+    name|startswith: 'PSEXESVC'
+  condition: selection and not filter
+falsepositives:
+  - Unknown
+level: high


### PR DESCRIPTION
Rules with related keyword fail to parse currently.  This should fix it.

Example related:
```
related:
    - id: 53ba33fd-3a50-4468-a5ef-c583635cfa92
      type: derived
```

Fixes https://github.com/bradleyjkemp/sigma-go/issues/19