### PR TITLE
Add ability to save rules from memory to sigma

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -2,6 +2,7 @@ package sigma
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bradleyjkemp/sigma-go/internal/grammar"
 )
@@ -11,20 +12,58 @@ type Condition struct {
 	Aggregation AggregationExpr
 }
 
+func (c Condition) MarshalYAML() (interface{}, error) {
+	search := c.Search.toString()
+	if c.Aggregation != nil {
+		return search + " | " + c.Aggregation.toString(), nil
+	} else {
+		return search, nil
+	}
+}
+
 type SearchExpr interface {
 	searchExpr()
+	toString() string
 }
 
 type And []SearchExpr
 
 func (And) searchExpr() {}
 
+func (e And) toString() string {
+	if len(e) == 1 {
+		return e[0].toString()
+	} else {
+		converted := make([]string, len(e))
+		for idx, sub := range e {
+			converted[idx] = sub.toString()
+		}
+		return "(" + strings.Join(converted, " and ") + ")"
+	}
+}
+
 type Or []SearchExpr
 
 func (Or) searchExpr() {}
 
+func (e Or) toString() string {
+	if len(e) == 1 {
+		return e[0].toString()
+	} else {
+		converted := make([]string, len(e))
+		for idx, sub := range e {
+			converted[idx] = sub.toString()
+		}
+		return "(" + strings.Join(converted, " or ") + ")"
+	}
+}
+
 type Not struct {
 	Expr SearchExpr
+}
+
+func (e Not) toString() string {
+	return "not " + e.Expr.toString()
 }
 
 func (Not) searchExpr() {}
@@ -35,11 +74,19 @@ type OneOfIdentifier struct {
 
 func (OneOfIdentifier) searchExpr() {}
 
+func (e OneOfIdentifier) toString() string {
+	return "1 of " + e.Ident.toString()
+}
+
 type AllOfIdentifier struct {
 	Ident SearchIdentifier
 }
 
 func (AllOfIdentifier) searchExpr() {}
+
+func (e AllOfIdentifier) toString() string {
+	return "all of " + e.Ident.toString()
+}
 
 type AllOfPattern struct {
 	Pattern string
@@ -47,19 +94,35 @@ type AllOfPattern struct {
 
 func (AllOfPattern) searchExpr() {}
 
+func (e AllOfPattern) toString() string {
+	return "all of " + e.Pattern
+}
+
 type OneOfPattern struct {
 	Pattern string
 }
 
 func (OneOfPattern) searchExpr() {}
 
+func (e OneOfPattern) toString() string {
+	return "1 of " + e.Pattern
+}
+
 type OneOfThem struct{}
 
 func (OneOfThem) searchExpr() {}
 
+func (OneOfThem) toString() string {
+	return "1 of them"
+}
+
 type AllOfThem struct{}
 
 func (AllOfThem) searchExpr() {}
+
+func (AllOfThem) toString() string {
+	return "all of them"
+}
 
 type SearchIdentifier struct {
 	Name string
@@ -67,8 +130,13 @@ type SearchIdentifier struct {
 
 func (SearchIdentifier) searchExpr() {}
 
+func (e SearchIdentifier) toString() string {
+	return e.Name
+}
+
 type AggregationExpr interface {
 	aggregationExpr()
+	toString() string
 }
 
 type Near struct {
@@ -96,8 +164,13 @@ type Comparison struct {
 
 func (Comparison) aggregationExpr() {}
 
+func (e Comparison) toString() string {
+	return fmt.Sprintf("%v %v %v", e.Func.toString(), e.Op, e.Threshold)
+}
+
 type AggregationFunc interface {
 	aggregationFunc()
+	toString() string
 }
 
 type Count struct {
@@ -107,12 +180,28 @@ type Count struct {
 
 func (Count) aggregationFunc() {}
 
+func (c Count) toString() string {
+	result := "count(" + c.Field + ")"
+	if c.GroupedBy != "" {
+		result += " by " + c.GroupedBy
+	}
+	return result
+}
+
 type Min struct {
 	Field     string
 	GroupedBy string
 }
 
 func (Min) aggregationFunc() {}
+
+func (c Min) toString() string {
+	result := "min(" + c.Field + ")"
+	if c.GroupedBy != "" {
+		result += " by " + c.GroupedBy
+	}
+	return result
+}
 
 type Max struct {
 	Field     string
@@ -121,6 +210,14 @@ type Max struct {
 
 func (Max) aggregationFunc() {}
 
+func (c Max) toString() string {
+	result := "max(" + c.Field + ")"
+	if c.GroupedBy != "" {
+		result += " by " + c.GroupedBy
+	}
+	return result
+}
+
 type Average struct {
 	Field     string
 	GroupedBy string
@@ -128,12 +225,28 @@ type Average struct {
 
 func (Average) aggregationFunc() {}
 
+func (c Average) toString() string {
+	result := "avg(" + c.Field + ")"
+	if c.GroupedBy != "" {
+		result += " by " + c.GroupedBy
+	}
+	return result
+}
+
 type Sum struct {
 	Field     string
 	GroupedBy string
 }
 
 func (Sum) aggregationFunc() {}
+
+func (c Sum) toString() string {
+	result := "sum(" + c.Field + ")"
+	if c.GroupedBy != "" {
+		result += " by " + c.GroupedBy
+	}
+	return result
+}
 
 func searchToAST(node interface{}) (SearchExpr, error) {
 	switch n := node.(type) {

--- a/ast.go
+++ b/ast.go
@@ -145,6 +145,10 @@ type Near struct {
 
 func (Near) aggregationExpr() {}
 
+func (n Near) toString() string {
+	return "near " + n.Condition.toString()
+}
+
 type ComparisonOp string
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/alecthomas/participle v0.7.1
 	github.com/bradleyjkemp/cupaloy/v2 v2.6.0
+	github.com/google/go-cmp v0.5.9
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/bradleyjkemp/cupaloy/v2 v2.6.0/go.mod h1:bm7JXdkRd4BHJk9HpwqAI8BoAY1l
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -14,14 +14,14 @@ type Rule struct {
 	Logsource Logsource
 	Detection Detection
 
-	ID          string
-	Related     []RelatedRule
-	Status      string
-	Description string
-	Author      string
-	Level       string
-	References  []string
-	Tags        []string
+	ID          string        `yaml:",omitempty"`
+	Related     []RelatedRule `yaml:",omitempty"`
+	Status      string        `yaml:",omitempty"`
+	Description string        `yaml:",omitempty"`
+	Author      string        `yaml:",omitempty"`
+	Level       string        `yaml:",omitempty"`
+	References  []string      `yaml:",omitempty"`
+	Tags        []string      `yaml:",omitempty"`
 
 	// Any non-standard fields will end up in here
 	AdditionalFields map[string]interface{} `yaml:",inline"`
@@ -33,10 +33,10 @@ type RelatedRule struct {
 }
 
 type Logsource struct {
-	Category   string
-	Product    string
-	Service    string
-	Definition string
+	Category   string `yaml:",omitempty"`
+	Product    string `yaml:",omitempty"`
+	Service    string `yaml:",omitempty"`
+	Definition string `yaml:",omitempty"`
 
 	// Any non-standard fields will end up in here
 	AdditionalFields map[string]interface{} `yaml:",inline"`

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -214,10 +214,10 @@ func (f *FieldMatcher) marshal() (field_node *yaml.Node, value_node *yaml.Node, 
 
 	// Encode the field value(s)
 	value_node = &yaml.Node{}
-	if len(f.Values) > 1 {
-		err = value_node.Encode(&f.Values)
-	} else {
+	if len(f.Values) == 1 {
 		err = value_node.Encode(&f.Values[0])
+	} else {
+		err = value_node.Encode(&f.Values)
 	}
 	if err != nil {
 		return nil, nil, err

--- a/rule_parser_test.go
+++ b/rule_parser_test.go
@@ -79,7 +79,7 @@ func TestMarshalRule(t *testing.T) {
 				t.Fatalf("error decoding rule copy: %v", err)
 			}
 
-			if !cmp.Equal(rule.Detection, rule_copy.Detection) {
+			if !cmp.Equal(rule, rule_copy) {
 				t.Fatalf("rule and marshalled copy are not equal")
 			}
 

--- a/rule_parser_test.go
+++ b/rule_parser_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy/v2"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseRule(t *testing.T) {
@@ -25,6 +27,60 @@ func TestParseRule(t *testing.T) {
 			rule, err := ParseRule(contents)
 			if err != nil {
 				t.Fatalf("error parsing rule: %v", err)
+			}
+
+			cupaloy.New(cupaloy.SnapshotSubdirectory("testdata")).SnapshotT(t, rule)
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMarshalRule(t *testing.T) {
+	err := filepath.Walk("./testdata/", func(path string, info os.FileInfo, err error) error {
+		if !strings.HasSuffix(path, ".rule.yml") {
+			return nil
+		}
+
+		t.Run(strings.TrimSuffix(filepath.Base(path), ".rule.yml"), func(t *testing.T) {
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed reading test input: %v", err)
+			}
+
+			rule, err := ParseRule(contents)
+			if err != nil {
+				t.Fatalf("error parsing rule: %v", err)
+			}
+
+			// Create a new temporary file in our testing temp directory
+			stream, err := os.CreateTemp(t.TempDir(), filepath.Base(path))
+			if err != nil {
+				t.Fatalf("error creating temp rule file: %v", err)
+			}
+			defer os.Remove(stream.Name())
+			defer stream.Close()
+
+			// Save the rule to a temporary file
+			encoder := yaml.NewEncoder(stream)
+			if err := encoder.Encode(&rule); err != nil {
+				t.Fatalf("error encoding rule to file: %v", err)
+			}
+
+			// Return to the beginning of the stream
+			stream.Seek(0, os.SEEK_SET)
+
+			// Re-read the rule from the newly serialized file
+			var rule_copy Rule
+			decoder := yaml.NewDecoder(stream)
+			if err := decoder.Decode(&rule_copy); err != nil {
+				t.Fatalf("error decoding rule copy: %v", err)
+			}
+
+			if !cmp.Equal(rule.Detection, rule_copy.Detection) {
+				t.Fatalf("rule and marshalled copy are not equal")
 			}
 
 			cupaloy.New(cupaloy.SnapshotSubdirectory("testdata")).SnapshotT(t, rule)

--- a/rule_parser_test.go
+++ b/rule_parser_test.go
@@ -82,8 +82,6 @@ func TestMarshalRule(t *testing.T) {
 			if !cmp.Equal(rule, rule_copy) {
 				t.Fatalf("rule and marshalled copy are not equal")
 			}
-
-			cupaloy.New(cupaloy.SnapshotSubdirectory("testdata")).SnapshotT(t, rule)
 		})
 		return nil
 	})

--- a/testdata/TestMarshalRule-proc_creation_win_apt_chafer_mar18
+++ b/testdata/TestMarshalRule-proc_creation_win_apt_chafer_mar18
@@ -1,0 +1,155 @@
+(sigma.Rule) {
+  Title: (string) (len=15) "Chafer Activity",
+  Logsource: (sigma.Logsource) {
+    Category: (string) (len=16) "process_creation",
+    Product: (string) (len=7) "windows",
+    Service: (string) "",
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
+  },
+  Detection: (sigma.Detection) {
+    Searches: (map[string]sigma.Search) (len=4) {
+      (string) (len=18) "selection_process0": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=12) "\\Service.exe"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=2) {
+                (string) (len=1) "i",
+                (string) (len=1) "u"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=18) "selection_process1": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=2) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=30) "\\microsoft\\Taskbar\\autoit3.exe"
+              }
+            }
+          },
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=10) "startswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=10) "C:\\wsc.exe"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=18) "selection_process2": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=17) "\\Windows\\Temp\\DB\\"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=4) ".exe"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=18) "selection_process3": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]string) (len=2) {
+                (string) (len=13) "\\nslookup.exe",
+                (string) (len=6) "-q=TXT"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "ParentImage",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=7) "\\Autoit"
+              }
+            }
+          }
+        }
+      }
+    },
+    Conditions: (sigma.Conditions) (len=1) {
+      (sigma.Condition) {
+        Search: (sigma.OneOfPattern) {
+          Pattern: (string) (len=10) "selection*"
+        },
+        Aggregation: (sigma.AggregationExpr) <nil>
+      }
+    },
+    Timeframe: (time.Duration) 0s
+  },
+  ID: (string) (len=36) "ce6e34ca-966d-41c9-8d93-5b06c8b97a06",
+  Related: ([]sigma.RelatedRule) <nil>,
+  Status: (string) (len=4) "test",
+  Description: (string) (len=88) "Detects Chafer activity attributed to OilRig as reported in Nyotron report in March 2018",
+  Author: (string) (len=82) "Florian Roth, Markus Neis, Jonhnathan Ribeiro, Daniil Yugoslavskiy, oscd.community",
+  Level: (string) (len=4) "high",
+  References: ([]string) (len=1) {
+    (string) (len=69) "https://nyotron.com/nyotron-discovers-next-generation-oilrig-attacks/"
+  },
+  Tags: ([]string) (len=9) {
+    (string) (len=18) "attack.persistence",
+    (string) (len=12) "attack.g0049",
+    (string) (len=16) "attack.t1053.005",
+    (string) (len=12) "attack.s0111",
+    (string) (len=16) "attack.t1543.003",
+    (string) (len=22) "attack.defense_evasion",
+    (string) (len=12) "attack.t1112",
+    (string) (len=26) "attack.command_and_control",
+    (string) (len=16) "attack.t1071.004"
+  },
+  AdditionalFields: (map[string]interface {}) (len=3) {
+    (string) (len=4) "date": (string) (len=10) "2018/03/23",
+    (string) (len=14) "falsepositives": ([]interface {}) (len=1) {
+      (string) (len=7) "Unknown"
+    },
+    (string) (len=8) "modified": (string) (len=10) "2021/09/19"
+  }
+}

--- a/testdata/TestMarshalRule-proxy_apt40
+++ b/testdata/TestMarshalRule-proxy_apt40
@@ -1,0 +1,74 @@
+(sigma.Rule) {
+  Title: (string) (len=29) "APT40 Dropbox Tool User Agent",
+  Logsource: (sigma.Logsource) {
+    Category: (string) (len=5) "proxy",
+    Product: (string) "",
+    Service: (string) "",
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
+  },
+  Detection: (sigma.Detection) {
+    Searches: (map[string]sigma.Search) (len=1) {
+      (string) (len=9) "selection": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=11) "c-useragent",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=109) "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=5) "r-dns",
+              Modifiers: ([]string) {
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=15) "api.dropbox.com"
+              }
+            }
+          }
+        }
+      }
+    },
+    Conditions: (sigma.Conditions) (len=1) {
+      (sigma.Condition) {
+        Search: (sigma.SearchIdentifier) {
+          Name: (string) (len=9) "selection"
+        },
+        Aggregation: (sigma.AggregationExpr) <nil>
+      }
+    },
+    Timeframe: (time.Duration) 0s
+  },
+  ID: (string) (len=36) "5ba715b6-71b7-44fd-8245-f66893e81b3d",
+  Related: ([]sigma.RelatedRule) <nil>,
+  Status: (string) (len=12) "experimental",
+  Description: (string) (len=58) "Detects suspicious user agent string of APT40 Dropbox tool",
+  Author: (string) (len=13) "Thomas Patzke",
+  Level: (string) (len=4) "high",
+  References: ([]string) (len=1) {
+    (string) (len=35) "Internal research from Florian Roth"
+  },
+  Tags: ([]string) (len=6) {
+    (string) (len=26) "attack.command_and_control",
+    (string) (len=16) "attack.t1071.001",
+    (string) (len=12) "attack.t1043",
+    (string) (len=19) "attack.exfiltration",
+    (string) (len=16) "attack.t1567.002",
+    (string) (len=12) "attack.t1048"
+  },
+  AdditionalFields: (map[string]interface {}) (len=4) {
+    (string) (len=4) "date": (string) (len=10) "2019/11/12",
+    (string) (len=14) "falsepositives": ([]interface {}) (len=1) {
+      (string) (len=12) "Old browsers"
+    },
+    (string) (len=6) "fields": ([]interface {}) (len=2) {
+      (string) (len=4) "c-ip",
+      (string) (len=5) "c-uri"
+    },
+    (string) (len=8) "modified": (string) (len=10) "2020/09/02"
+  }
+}

--- a/testdata/TestMarshalRule-zeek_smb_converted_win_susp_psexec
+++ b/testdata/TestMarshalRule-zeek_smb_converted_win_susp_psexec
@@ -1,0 +1,100 @@
+(sigma.Rule) {
+  Title: (string) (len=34) "Suspicious PsExec Execution - Zeek",
+  Logsource: (sigma.Logsource) {
+    Category: (string) "",
+    Product: (string) (len=4) "zeek",
+    Service: (string) (len=9) "smb_files",
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
+  },
+  Detection: (sigma.Detection) {
+    Searches: (map[string]sigma.Search) (len=2) {
+      (string) (len=6) "filter": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=4) "name",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=10) "startswith"
+              },
+              Values: ([]string) (len=1) {
+                (string) (len=8) "PSEXESVC"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=9) "selection": (sigma.Search) {
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              Field: (string) (len=4) "path",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]string) (len=2) {
+                (string) (len=2) "\\\\",
+                (string) (len=5) "\\IPC$"
+              }
+            },
+            (sigma.FieldMatcher) {
+              Field: (string) (len=4) "name",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]string) (len=3) {
+                (string) (len=6) "-stdin",
+                (string) (len=7) "-stdout",
+                (string) (len=7) "-stderr"
+              }
+            }
+          }
+        }
+      }
+    },
+    Conditions: (sigma.Conditions) (len=1) {
+      (sigma.Condition) {
+        Search: (sigma.And) (len=2) {
+          (sigma.SearchIdentifier) {
+            Name: (string) (len=9) "selection"
+          },
+          (sigma.Not) {
+            Expr: (sigma.SearchIdentifier) {
+              Name: (string) (len=6) "filter"
+            }
+          }
+        },
+        Aggregation: (sigma.AggregationExpr) <nil>
+      }
+    },
+    Timeframe: (time.Duration) 0s
+  },
+  ID: (string) (len=36) "f1b3a22a-45e6-4004-afb5-4291f9c21166",
+  Related: ([]sigma.RelatedRule) (len=1) {
+    (sigma.RelatedRule) {
+      ID: (string) (len=36) "c462f537-a1e3-41a6-b5fc-b2c2cef9bf82",
+      Type: (string) (len=7) "derived"
+    }
+  },
+  Status: (string) (len=4) "test",
+  Description: (string) (len=214) "detects execution of psexec or paexec with renamed service name, this rule helps to filter out the noise if psexec is used for legit purposes or if attacker uses a different psexec client other than sysinternal one",
+  Author: (string) (len=39) "Samir Bousseaden, @neu5ron, Tim Shelton",
+  Level: (string) (len=4) "high",
+  References: ([]string) (len=1) {
+    (string) (len=71) "https://blog.menasec.net/2019/02/threat-hunting-3-detecting-psexec.html"
+  },
+  Tags: ([]string) (len=2) {
+    (string) (len=23) "attack.lateral_movement",
+    (string) (len=16) "attack.t1021.002"
+  },
+  AdditionalFields: (map[string]interface {}) (len=3) {
+    (string) (len=4) "date": (string) (len=10) "2020/04/02",
+    (string) (len=14) "falsepositives": ([]interface {}) (len=1) {
+      (string) (len=7) "Unknown"
+    },
+    (string) (len=8) "modified": (string) (len=10) "2022/12/27"
+  }
+}


### PR DESCRIPTION
This PR adds the ability to marshal a Sigma rule from memory back to a compliant YAML-formatted Sigma rule on disk. This allows users of the library to in theory modify or fully create rules in memory and then save them back to disk.

For the most part, this is straightforward. The only semi-complicated piece was marshalling the condition expression back properly. For this, I added a `toString` method to the AST objects to do context-aware construction of the expression, and then put the search expression and optional aggregation expression back together in the a `Marshal` implementation for `Condition`.

I added a test, but it's not great. The marshalling process produces a logically identical rule, but some of the fields end up with their default empty values being marshalled back out to the file, so a one-to-one comparison doesn't work. I used the Google `cmp` package to compare the re-loaded `Detection` representation in the test to ensure the detection was the same, since that is arguably the most important part of the rule itself. Anectdotally, the other fields seem to be marshalled properly during my testing.

As far as a use-case/motivation here, I am building a sort of rule "bundler" which puts a library of rules together into a single file for uploading to an engine. I'd like to load the rules, validate them, and then output a composite file with all the validated rules. If the `Rule` struct can completely implement the `yaml.Marshaler` interface, then this is super simple.

If you have an ideas for better improving the marshalling or the test case, let me know. I'm open to opinions here. This is just a first stab that seems to be working for me. :)