### PR TITLE
Expose position information for key rule parts

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -23,8 +23,9 @@ func (c Condition) MarshalYAML() (interface{}, error) {
 	}
 }
 
-func (c Condition) RawYAML() *yaml.Node {
-	return c.node
+// Position returns the line and column of this Condition in the original input
+func (c Condition) Position() (int, int) {
+	return c.node.Line - 1, c.node.Column - 1
 }
 
 type SearchExpr interface {

--- a/ast.go
+++ b/ast.go
@@ -2,12 +2,14 @@ package sigma
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"strings"
 
 	"github.com/bradleyjkemp/sigma-go/internal/grammar"
 )
 
 type Condition struct {
+	node        *yaml.Node
 	Search      SearchExpr
 	Aggregation AggregationExpr
 }
@@ -19,6 +21,10 @@ func (c Condition) MarshalYAML() (interface{}, error) {
 	} else {
 		return search, nil
 	}
+}
+
+func (c Condition) RawYAML() *yaml.Node {
+	return c.node
 }
 
 type SearchExpr interface {

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -130,8 +130,9 @@ func (s *Search) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
-func (s Search) RawYAML() *yaml.Node {
-	return s.node
+// Position returns the line and column of this Search in the original input
+func (s Search) Position() (int, int) {
+	return s.node.Line - 1, s.node.Column - 1
 }
 
 func (s Search) MarshalYAML() (interface{}, error) {
@@ -196,6 +197,11 @@ type FieldMatcher struct {
 	Field     string
 	Modifiers []string
 	Values    []interface{}
+}
+
+// Position returns the line and column of this FieldMatcher in the original input
+func (f FieldMatcher) Position() (int, int) {
+	return f.node.Line - 1, f.node.Column - 1
 }
 
 func (f *FieldMatcher) unmarshal(field *yaml.Node, values *yaml.Node) error {

--- a/rule_parser.go
+++ b/rule_parser.go
@@ -136,6 +136,7 @@ type Search struct {
 }
 
 func (s *Search) UnmarshalYAML(node *yaml.Node) error {
+	s.node = node
 	switch node.Kind {
 	// In the common case, SearchIdentifiers are a single EventMatcher (map of field names to values)
 	case yaml.MappingNode:

--- a/rule_parser_test.go
+++ b/rule_parser_test.go
@@ -1,6 +1,7 @@
 package sigma
 
 import (
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -79,7 +80,7 @@ func TestMarshalRule(t *testing.T) {
 				t.Fatalf("error decoding rule copy: %v", err)
 			}
 
-			if !cmp.Equal(rule, rule_copy) {
+			if !cmp.Equal(rule, rule_copy, cmpopts.IgnoreUnexported(Condition{}, FieldMatcher{}, Search{})) {
 				t.Fatalf("rule and marshalled copy are not equal")
 			}
 		})

--- a/testdata/TestParseConfig-sysmon
+++ b/testdata/TestParseConfig-sysmon
@@ -14,10 +14,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 26,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=2) "22",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 26,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 26,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 26,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -46,10 +103,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 69,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "6",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 69,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 69,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 69,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -78,10 +192,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 45,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=2) "11",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 45,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 45,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 45,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -110,10 +281,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 61,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "7",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 61,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 61,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 61,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -142,10 +370,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 18,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "3",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 18,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 18,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 18,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -174,10 +459,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 53,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=2) "10",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 53,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 53,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 53,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -206,10 +548,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 10,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "1",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 10,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 10,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 10,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -238,10 +637,67 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 77,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "5",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 77,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 77,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 77,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },
@@ -270,10 +726,110 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 34,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 2,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!seq",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=3) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!int",
+                  Value: (string) (len=2) "12",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 35,
+                  Column: (int) 11
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!int",
+                  Value: (string) (len=2) "13",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 36,
+                  Column: (int) 11
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!int",
+                  Value: (string) (len=2) "14",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 37,
+                  Column: (int) 11
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 35,
+              Column: (int) 9
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 34,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=7) "EventID",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 34,
+                Column: (int) 7
+              }),
               Field: (string) (len=7) "EventID",
               Modifiers: ([]string) {
               },

--- a/testdata/TestParseConfig-sysmon
+++ b/testdata/TestParseConfig-sysmon
@@ -14,7 +14,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 26,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=2) "22",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 26,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 26,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -61,7 +103,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 69,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "6",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 69,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 69,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -108,7 +192,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 45,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=2) "11",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 45,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 45,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -155,7 +281,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 61,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "7",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 61,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 61,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -202,7 +370,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 18,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "3",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 18,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 18,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -249,7 +459,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 53,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=2) "10",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 53,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 53,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -296,7 +548,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 10,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "1",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 10,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 10,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -343,7 +637,49 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 77,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!int",
+              Value: (string) (len=1) "5",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 77,
+              Column: (int) 16
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 77,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -390,7 +726,92 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)(<nil>),
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "EventID",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 34,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 2,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!seq",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=3) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!int",
+                  Value: (string) (len=2) "12",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 35,
+                  Column: (int) 11
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!int",
+                  Value: (string) (len=2) "13",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 36,
+                  Column: (int) 11
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!int",
+                  Value: (string) (len=2) "14",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 37,
+                  Column: (int) 11
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 35,
+              Column: (int) 9
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 34,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {

--- a/testdata/TestParseConfig-sysmon
+++ b/testdata/TestParseConfig-sysmon
@@ -14,49 +14,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 26,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=2) "22",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 26,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 26,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -103,49 +61,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 69,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=1) "6",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 69,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 69,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -192,49 +108,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 45,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=2) "11",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 45,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 45,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -281,49 +155,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 61,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=1) "7",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 61,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 61,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -370,49 +202,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 18,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=1) "3",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 18,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 18,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -459,49 +249,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 53,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=2) "10",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 53,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 53,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -548,49 +296,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 10,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=1) "1",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 10,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 10,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -637,49 +343,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 77,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!int",
-              Value: (string) (len=1) "5",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 77,
-              Column: (int) 16
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 77,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
@@ -726,92 +390,7 @@
       },
       Index: (sigma.LogsourceIndexes) <nil>,
       Conditions: (sigma.Search) {
-        node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
-          Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
-          Anchor: (string) "",
-          Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "EventID",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 34,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 2,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!seq",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=3) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 0,
-                  Tag: (string) (len=5) "!!int",
-                  Value: (string) (len=2) "12",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 35,
-                  Column: (int) 11
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 0,
-                  Tag: (string) (len=5) "!!int",
-                  Value: (string) (len=2) "13",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 36,
-                  Column: (int) 11
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 0,
-                  Tag: (string) (len=5) "!!int",
-                  Value: (string) (len=2) "14",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 37,
-                  Column: (int) 11
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 35,
-              Column: (int) 9
-            })
-          },
-          HeadComment: (string) "",
-          LineComment: (string) "",
-          FootComment: (string) "",
-          Line: (int) 34,
-          Column: (int) 7
-        }),
+        node: (*yaml.Node)(<nil>),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {

--- a/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
+++ b/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
@@ -11,104 +11,18 @@
     Searches: (map[string]sigma.Search) (len=4) {
       (string) (len=18) "selection_process0": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=18) "selection_process0",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=4) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=20) "CommandLine|contains",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 28,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=12) "\\Service.exe",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 28,
-              Column: (int) 27
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=20) "CommandLine|endswith",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 29,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 2,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!seq",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=2) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=1) "i",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 30,
-                  Column: (int) 9
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=1) "u",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 31,
-                  Column: (int) 9
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 30,
-              Column: (int) 7
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 28,
-          Column: (int) 5
+          Line: (int) 27,
+          Column: (int) 3
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
@@ -165,105 +79,18 @@
       },
       (string) (len=18) "selection_process1": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 2,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!seq",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=18) "selection_process1",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 4,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!map",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=2) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 0,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=20) "CommandLine|endswith",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 33,
-                  Column: (int) 7
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=30) "\\microsoft\\Taskbar\\autoit3.exe",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 33,
-                  Column: (int) 29
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 33,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 4,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!map",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=2) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 0,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=22) "CommandLine|startswith",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 34,
-                  Column: (int) 7
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=10) "C:\\wsc.exe",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 34,
-                  Column: (int) 31
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 34,
-              Column: (int) 7
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 33,
-          Column: (int) 5
+          Line: (int) 32,
+          Column: (int) 3
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=2) {
@@ -321,75 +148,18 @@
       },
       (string) (len=18) "selection_process2": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=18) "selection_process2",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=4) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=14) "Image|contains",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 36,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=17) "\\Windows\\Temp\\DB\\",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 36,
-              Column: (int) 21
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=14) "Image|endswith",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 37,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=4) ".exe",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 37,
-              Column: (int) 21
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 36,
-          Column: (int) 5
+          Line: (int) 35,
+          Column: (int) 3
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
@@ -445,104 +215,18 @@
       },
       (string) (len=18) "selection_process3": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=18) "selection_process3",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=4) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=24) "CommandLine|contains|all",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 39,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 2,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!seq",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=2) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=13) "\\nslookup.exe",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 40,
-                  Column: (int) 9
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=6) "-q=TXT",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 41,
-                  Column: (int) 9
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 40,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=20) "ParentImage|contains",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 42,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=7) "\\Autoit",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 42,
-              Column: (int) 27
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 39,
-          Column: (int) 5
+          Line: (int) 38,
+          Column: (int) 3
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {

--- a/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
+++ b/testdata/TestParseRule-proc_creation_win_apt_chafer_mar18
@@ -10,10 +10,124 @@
   Detection: (sigma.Detection) {
     Searches: (map[string]sigma.Search) (len=4) {
       (string) (len=18) "selection_process0": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=4) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=20) "CommandLine|contains",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 28,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=12) "\\Service.exe",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 28,
+              Column: (int) 27
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=20) "CommandLine|endswith",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 29,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 2,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!seq",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=2) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=1) "i",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 30,
+                  Column: (int) 9
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=1) "u",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 31,
+                  Column: (int) 9
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 30,
+              Column: (int) 7
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 28,
+          Column: (int) 5
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=2) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "CommandLine|contains",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 28,
+                Column: (int) 5
+              }),
               Field: (string) (len=11) "CommandLine",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "contains"
@@ -23,6 +137,20 @@
               }
             },
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "CommandLine|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 29,
+                Column: (int) 5
+              }),
               Field: (string) (len=11) "CommandLine",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "endswith"
@@ -36,10 +164,125 @@
         }
       },
       (string) (len=18) "selection_process1": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 2,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!seq",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 4,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!map",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=2) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=20) "CommandLine|endswith",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 33,
+                  Column: (int) 7
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=30) "\\microsoft\\Taskbar\\autoit3.exe",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 33,
+                  Column: (int) 29
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 33,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 4,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!map",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=2) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 0,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=22) "CommandLine|startswith",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 34,
+                  Column: (int) 7
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=10) "C:\\wsc.exe",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 34,
+                  Column: (int) 31
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 34,
+              Column: (int) 7
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 33,
+          Column: (int) 5
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=2) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "CommandLine|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 33,
+                Column: (int) 7
+              }),
               Field: (string) (len=11) "CommandLine",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "endswith"
@@ -51,6 +294,20 @@
           },
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=22) "CommandLine|startswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 34,
+                Column: (int) 7
+              }),
               Field: (string) (len=11) "CommandLine",
               Modifiers: ([]string) (len=1) {
                 (string) (len=10) "startswith"
@@ -63,10 +320,95 @@
         }
       },
       (string) (len=18) "selection_process2": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=4) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=14) "Image|contains",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 36,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=17) "\\Windows\\Temp\\DB\\",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 36,
+              Column: (int) 21
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=14) "Image|endswith",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 37,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=4) ".exe",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 37,
+              Column: (int) 21
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 36,
+          Column: (int) 5
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=2) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=14) "Image|contains",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 36,
+                Column: (int) 5
+              }),
               Field: (string) (len=5) "Image",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "contains"
@@ -76,6 +418,20 @@
               }
             },
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=14) "Image|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 37,
+                Column: (int) 5
+              }),
               Field: (string) (len=5) "Image",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "endswith"
@@ -88,10 +444,124 @@
         }
       },
       (string) (len=18) "selection_process3": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=4) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=24) "CommandLine|contains|all",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 39,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 2,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!seq",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=2) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=13) "\\nslookup.exe",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 40,
+                  Column: (int) 9
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=6) "-q=TXT",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 41,
+                  Column: (int) 9
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 40,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=20) "ParentImage|contains",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 42,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=7) "\\Autoit",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 42,
+              Column: (int) 27
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 39,
+          Column: (int) 5
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=2) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=24) "CommandLine|contains|all",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 39,
+                Column: (int) 5
+              }),
               Field: (string) (len=11) "CommandLine",
               Modifiers: ([]string) (len=2) {
                 (string) (len=8) "contains",
@@ -103,6 +573,20 @@
               }
             },
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "ParentImage|contains",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 42,
+                Column: (int) 5
+              }),
               Field: (string) (len=11) "ParentImage",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "contains"
@@ -117,6 +601,20 @@
     },
     Conditions: (sigma.Conditions) (len=1) {
       (sigma.Condition) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=15) "1 of selection*",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 43,
+          Column: (int) 14
+        }),
         Search: (sigma.OneOfPattern) {
           Pattern: (string) (len=10) "selection*"
         },

--- a/testdata/TestParseRule-proxy_apt40
+++ b/testdata/TestParseRule-proxy_apt40
@@ -11,75 +11,18 @@
     Searches: (map[string]sigma.Search) (len=1) {
       (string) (len=9) "selection": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=9) "selection",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=4) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=11) "c-useragent",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 23,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=109) "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 23,
-              Column: (int) 20
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=5) "r-dns",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 24,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=15) "api.dropbox.com",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 24,
-              Column: (int) 14
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 23,
-          Column: (int) 7
+          Line: (int) 22,
+          Column: (int) 5
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {

--- a/testdata/TestParseRule-proxy_apt40
+++ b/testdata/TestParseRule-proxy_apt40
@@ -10,10 +10,95 @@
   Detection: (sigma.Detection) {
     Searches: (map[string]sigma.Search) (len=1) {
       (string) (len=9) "selection": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=4) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=11) "c-useragent",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 23,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=109) "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 23,
+              Column: (int) 20
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=5) "r-dns",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 24,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=15) "api.dropbox.com",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 24,
+              Column: (int) 14
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 23,
+          Column: (int) 7
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=2) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=11) "c-useragent",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 23,
+                Column: (int) 7
+              }),
               Field: (string) (len=11) "c-useragent",
               Modifiers: ([]string) {
               },
@@ -22,6 +107,20 @@
               }
             },
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=5) "r-dns",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 24,
+                Column: (int) 7
+              }),
               Field: (string) (len=5) "r-dns",
               Modifiers: ([]string) {
               },
@@ -35,6 +134,20 @@
     },
     Conditions: (sigma.Conditions) (len=1) {
       (sigma.Condition) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=9) "selection",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 25,
+          Column: (int) 16
+        }),
         Search: (sigma.SearchIdentifier) {
           Name: (string) (len=9) "selection"
         },

--- a/testdata/TestParseRule-zeek_smb_converted_win_susp_psexec
+++ b/testdata/TestParseRule-zeek_smb_converted_win_susp_psexec
@@ -10,10 +10,67 @@
   Detection: (sigma.Detection) {
     Searches: (map[string]sigma.Search) (len=2) {
       (string) (len=6) "filter": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=2) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=15) "name|startswith",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 29,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 4,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=8) "PSEXESVC",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 29,
+              Column: (int) 22
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 29,
+          Column: (int) 5
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=1) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=15) "name|startswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 29,
+                Column: (int) 5
+              }),
               Field: (string) (len=4) "name",
               Modifiers: ([]string) (len=1) {
                 (string) (len=10) "startswith"
@@ -26,10 +83,167 @@
         }
       },
       (string) (len=9) "selection": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 4,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!map",
+          Value: (string) "",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) (len=4) {
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=17) "path|contains|all",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 21,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 2,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!seq",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=2) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=2) "\\\\",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 22,
+                  Column: (int) 9
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=5) "\\IPC$",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 23,
+                  Column: (int) 9
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 22,
+              Column: (int) 7
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 8,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!str",
+              Value: (string) (len=13) "name|endswith",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) <nil>,
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 24,
+              Column: (int) 5
+            }),
+            (*yaml.Node)({
+              Kind: (yaml.Kind) 2,
+              Style: (yaml.Style) 0,
+              Tag: (string) (len=5) "!!seq",
+              Value: (string) "",
+              Anchor: (string) "",
+              Alias: (*yaml.Node)(<nil>),
+              Content: ([]*yaml.Node) (len=3) {
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=6) "-stdin",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 25,
+                  Column: (int) 9
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=7) "-stdout",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 26,
+                  Column: (int) 9
+                }),
+                (*yaml.Node)({
+                  Kind: (yaml.Kind) 8,
+                  Style: (yaml.Style) 4,
+                  Tag: (string) (len=5) "!!str",
+                  Value: (string) (len=7) "-stderr",
+                  Anchor: (string) "",
+                  Alias: (*yaml.Node)(<nil>),
+                  Content: ([]*yaml.Node) <nil>,
+                  HeadComment: (string) "",
+                  LineComment: (string) "",
+                  FootComment: (string) "",
+                  Line: (int) 27,
+                  Column: (int) 9
+                })
+              },
+              HeadComment: (string) "",
+              LineComment: (string) "",
+              FootComment: (string) "",
+              Line: (int) 25,
+              Column: (int) 7
+            })
+          },
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 21,
+          Column: (int) 5
+        }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
           (sigma.EventMatcher) (len=2) {
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=17) "path|contains|all",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 21,
+                Column: (int) 5
+              }),
               Field: (string) (len=4) "path",
               Modifiers: ([]string) (len=2) {
                 (string) (len=8) "contains",
@@ -41,6 +255,20 @@
               }
             },
             (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=13) "name|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 24,
+                Column: (int) 5
+              }),
               Field: (string) (len=4) "name",
               Modifiers: ([]string) (len=1) {
                 (string) (len=8) "endswith"
@@ -57,6 +285,20 @@
     },
     Conditions: (sigma.Conditions) (len=1) {
       (sigma.Condition) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=24) "selection and not filter",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 30,
+          Column: (int) 14
+        }),
         Search: (sigma.And) (len=2) {
           (sigma.SearchIdentifier) {
             Name: (string) (len=9) "selection"

--- a/testdata/TestParseRule-zeek_smb_converted_win_susp_psexec
+++ b/testdata/TestParseRule-zeek_smb_converted_win_susp_psexec
@@ -11,47 +11,18 @@
     Searches: (map[string]sigma.Search) (len=2) {
       (string) (len=6) "filter": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=6) "filter",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=2) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=15) "name|startswith",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 29,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 4,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=8) "PSEXESVC",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 29,
-              Column: (int) 22
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 29,
-          Column: (int) 5
+          Line: (int) 28,
+          Column: (int) 3
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {
@@ -84,147 +55,18 @@
       },
       (string) (len=9) "selection": (sigma.Search) {
         node: (*yaml.Node)({
-          Kind: (yaml.Kind) 4,
+          Kind: (yaml.Kind) 8,
           Style: (yaml.Style) 0,
-          Tag: (string) (len=5) "!!map",
-          Value: (string) "",
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=9) "selection",
           Anchor: (string) "",
           Alias: (*yaml.Node)(<nil>),
-          Content: ([]*yaml.Node) (len=4) {
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=17) "path|contains|all",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 21,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 2,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!seq",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=2) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=2) "\\\\",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 22,
-                  Column: (int) 9
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=5) "\\IPC$",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 23,
-                  Column: (int) 9
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 22,
-              Column: (int) 7
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 8,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!str",
-              Value: (string) (len=13) "name|endswith",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) <nil>,
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 24,
-              Column: (int) 5
-            }),
-            (*yaml.Node)({
-              Kind: (yaml.Kind) 2,
-              Style: (yaml.Style) 0,
-              Tag: (string) (len=5) "!!seq",
-              Value: (string) "",
-              Anchor: (string) "",
-              Alias: (*yaml.Node)(<nil>),
-              Content: ([]*yaml.Node) (len=3) {
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=6) "-stdin",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 25,
-                  Column: (int) 9
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=7) "-stdout",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 26,
-                  Column: (int) 9
-                }),
-                (*yaml.Node)({
-                  Kind: (yaml.Kind) 8,
-                  Style: (yaml.Style) 4,
-                  Tag: (string) (len=5) "!!str",
-                  Value: (string) (len=7) "-stderr",
-                  Anchor: (string) "",
-                  Alias: (*yaml.Node)(<nil>),
-                  Content: ([]*yaml.Node) <nil>,
-                  HeadComment: (string) "",
-                  LineComment: (string) "",
-                  FootComment: (string) "",
-                  Line: (int) 27,
-                  Column: (int) 9
-                })
-              },
-              HeadComment: (string) "",
-              LineComment: (string) "",
-              FootComment: (string) "",
-              Line: (int) 25,
-              Column: (int) 7
-            })
-          },
+          Content: ([]*yaml.Node) <nil>,
           HeadComment: (string) "",
           LineComment: (string) "",
           FootComment: (string) "",
-          Line: (int) 21,
-          Column: (int) 5
+          Line: (int) 20,
+          Column: (int) 3
         }),
         Keywords: ([]string) <nil>,
         EventMatchers: ([]sigma.EventMatcher) (len=1) {


### PR DESCRIPTION
For the purposes of writing linters (e.g. https://github.com/bradleyjkemp/sigmafmt) it's useful to have position information for rule parts like conditions, searches, and field matchers.

This allows the linter to report contextual errors, linking to or directly highlighting the broken part of the rule