### PR TITLE
Add option to disable case insensitivity

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -30,7 +30,6 @@ type RuleEvaluator struct {
 // For example, if a Sigma rule has a condition like this (attempting to detect login brute forcing)
 //
 // detection:
-//
 //	  login_attempt:
 //	    # something here
 //	  condition:
@@ -41,7 +40,6 @@ type RuleEvaluator struct {
 // Each different GroupedByValues points to a different box.
 //
 // GroupedByValues
-//
 //	    ||
 //	 ___↓↓___          ________
 //	| User A |        | User B |

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -16,6 +16,7 @@ type RuleEvaluator struct {
 	fieldmappings   map[string][]string // a compiled mapping from rule fieldnames to possible event fieldnames
 
 	expandPlaceholder func(ctx context.Context, placeholderName string) ([]string, error)
+	caseSensitive     bool
 
 	count   func(ctx context.Context, gb GroupedByValues) (float64, error)
 	average func(ctx context.Context, gb GroupedByValues, value float64) (float64, error)
@@ -29,20 +30,22 @@ type RuleEvaluator struct {
 // For example, if a Sigma rule has a condition like this (attempting to detect login brute forcing)
 //
 // detection:
-//   login_attempt:
-//     # something here
-//   condition:
-//     login_attempt | count() by (username) > 100
-//	 timeframe: 1m
+//
+//	  login_attempt:
+//	    # something here
+//	  condition:
+//	    login_attempt | count() by (username) > 100
+//		 timeframe: 1m
 //
 // Conceptually there's a bunch of boxes somewhere (one for each username) containing their current count.
 // Each different GroupedByValues points to a different box.
 //
 // GroupedByValues
-//      ||
-//   ___↓↓___          ________
-//  | User A |        | User B |
-//  |__2041__|        |___01___|
+//
+//	    ||
+//	 ___↓↓___          ________
+//	| User A |        | User B |
+//	|__2041__|        |___01___|
 //
 // It's up to your implementation to ensure that different GroupedByValues map to different boxes
 // (although a default Key() method is provided which is good enough for most use cases)

--- a/evaluator/evaluate_search.go
+++ b/evaluator/evaluate_search.go
@@ -110,7 +110,13 @@ eventMatcher:
 			}
 
 			// field matchers can specify modifiers (FieldName|modifier1|modifier2) which change the matching behaviour
-			comparator, err := modifiers.GetComparator(fieldModifiers...)
+			var comparator modifiers.ComparatorFunc
+			var err error
+			if rule.caseSensitive {
+				comparator, err = modifiers.GetComparatorCaseSensitive(fieldModifiers...)
+			} else {
+				comparator, err = modifiers.GetComparator(fieldModifiers...)
+			}
 			if err != nil {
 				return false, err
 			}

--- a/evaluator/modifiers/modifiers_test.go
+++ b/evaluator/modifiers/modifiers_test.go
@@ -2,6 +2,7 @@ package modifiers
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 )
 
@@ -42,5 +43,41 @@ func Test_compareNumeric(t *testing.T) {
 				t.Errorf("compareNumeric() gotLte = %v, want %v", gotLte, tt.wantLte)
 			}
 		})
+	}
+}
+
+func BenchmarkContains(b *testing.B) {
+	needle := "abcdefg"
+
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	haystack := make([]rune, 1_000_000)
+	for i := range haystack {
+		haystack[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	haystackString := string(haystack)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := contains{}.Matches(string(haystackString), needle)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkContainsCS(b *testing.B) {
+	needle := "abcdefg"
+
+	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	haystack := make([]rune, 1_000_000)
+	for i := range haystack {
+		haystack[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	haystackString := string(haystack)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := containsCS{}.Matches(string(haystackString), needle)
+		if err != nil {
+			b.Fatal(err)
+		}
 	}
 }

--- a/evaluator/options.go
+++ b/evaluator/options.go
@@ -40,3 +40,9 @@ func WithConfig(config ...sigma.Config) Option {
 		e.calculateFieldMappings()
 	}
 }
+
+// CaseSensitive turns off the default Sigma behaviour that string operations are by default case-insensitive
+// This can increase performance (especially for larger events) by skipping expensive calls to strings.ToLower
+func CaseSensitive(e *RuleEvaluator) {
+	e.caseSensitive = true
+}


### PR DESCRIPTION
The Sigma spec defines that string operations are by default case insensitive. This is naively implemented at the moment by calling `strings.ToLower` on everything which can be extremely expensive (especially for large events: [phish.report](https://phish.report) spends 5-10% of CPU just on lowercasing strings!)

I've explored some better case insensitive matching implementations but they're all still massively more expensive than simply disabling case insensitivity:
```
goos: darwin
goarch: arm64
pkg: github.com/bradleyjkemp/sigma-go/evaluator/modifiers
BenchmarkContains-8                  200           5962780 ns/op         1007659 B/op          3 allocs/op
BenchmarkContainsCS-8               3002            399105 ns/op              32 B/op          2 allocs/op
PASS
```

This PR adds a config option to disable case insensitivity and instead use the much faster contains/startswith/endswith functions