### PR TITLE
Fixing conditions with multiple underscores and adding a working example for reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,22 @@
 # sigma-go ![Build Status](https://github.com/bradleyjkemp/sigma-go/workflows/Go/badge.svg) [![GitHub release](https://img.shields.io/github/release/bradleyjkemp/sigma-go.svg)](https://github.com/bradleyjkemp/sigma-go/releases/latest)
+
 <img src=".github/mascot.png" alt="Mascot" width="150" align="right">
 
 A Go implementation and parser of [Sigma rules](https://github.com/Neo23x0/sigma). Useful for building your own detection pipelines.
 
 Who's using `sigma-go` in production?
-* [Monzo Bank](https://monzo.com/blog/2022/08/05/scaling-our-security-detection-pipeline-with-sigma)
-* [Phish Report](https://phish.report/IOK)
-* [SysFlow](https://github.com/sysflow-telemetry)
+
+- [Monzo Bank](https://monzo.com/blog/2022/08/05/scaling-our-security-detection-pipeline-with-sigma)
+- [Phish Report](https://phish.report/IOK)
+- [SysFlow](https://github.com/sysflow-telemetry)
+
+## Installation
+
+````bash
+go get github.com/bradleyjkemp/sigma-go
+go get github.com/bradleyjkemp/sigma-go/evaluator
 
 ## Usage
-
 This library is designed for you to build your own alert systems.
 It exposes the ability to check whether a rule matches a given event but not much else.
 It's up to you to use this building block in your own detection pipeline.
@@ -30,13 +37,14 @@ for event := range events {
         newAlert(rule.ID, rule.Description, ...)
     }
 }
-```
+````
 
 ### Aggregation functions
 
 If your Sigma rules make use of the count, max, min, or any other aggregation function in your conditions then you'll need some extra setup.
 
 When creating an evaluator, you can pass in implementations of each of the aggregation functions:
+
 ```go
 sigma.Evaluator(rule, sigma.CountFunc(countImplementation), sigma.MaxFunc(maxImplementation))
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Who's using `sigma-go` in production?
 
 ````bash
 go get github.com/bradleyjkemp/sigma-go
-go get github.com/bradleyjkemp/sigma-go/evaluator
 
 ## Usage
 This library is designed for you to build your own alert systems.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ var rule, _ = sigma.ParseRule(contents)
 
 // Rules need to be wrapped in an evaluator.
 // This is also where (if needed) you provide functions implementing the count, max, etc. aggregation functions
-e := sigma.Evaluator(rule, options...)
-
+e := evaluator.ForRule(rule)
 // Get a stream of events from somewhere e.g. audit logs
 for event := range events {
     if e.Matches(ctx, event) {

--- a/condition_parser.go
+++ b/condition_parser.go
@@ -8,9 +8,9 @@ import (
 
 var (
 	searchExprLexer = lexer.Must(lexer.Regexp(`(?P<Keyword>(?i)(1 of them)|(all of them)|(1 of)|(all of))` +
-		`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+\*[a-zA-Z0-9_*]*)` +
-		`|(?P<SearchIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)` +
-		`|(?P<Operator>(?i)and|or|not|[()])` + // TODO: this never actually matches anything because they get matched as a SearchIdentifier instead. However this isn't currently a problem because we don't parse anything in the Grammar as an Operator (we just use string constants which don't care about Operator vs SearchIdentifier)
+		`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+(?:[a-zA-Z0-9_]*_)*[a-zA-Z0-9]*\*)` + // Adjusted pattern to catch multiple underscores which is present upstream
+		`|(?P<SearchIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)` + // TODO: this never actually matches anything because they get matched as a SearchIdentifier instead. However this isn't currently a problem because we don't parse anything in the Grammar as an Operator (we just use string constants which don't care about Operator vs SearchIdentifier)
+		`|(?P<Operator>(?i)and|or|not|[()])` +
 		`|(?P<ComparisonOperation>=|!=|<=|>=|<|>)` +
 		`|(?P<ComparisonValue>0|[1-9][0-9]*)` +
 		`|(?P<Pipe>[|])` +

--- a/evaluator/modifiers/modifiers_test.go
+++ b/evaluator/modifiers/modifiers_test.go
@@ -49,7 +49,7 @@ func Test_compareNumeric(t *testing.T) {
 func BenchmarkContains(b *testing.B) {
 	needle := "abcdefg"
 
-	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	haystack := make([]rune, 1_000_000)
 	for i := range haystack {
 		haystack[i] = letterRunes[rand.Intn(len(letterRunes))]
@@ -67,7 +67,7 @@ func BenchmarkContains(b *testing.B) {
 func BenchmarkContainsCS(b *testing.B) {
 	needle := "abcdefg"
 
-	var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	letterRunes := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	haystack := make([]rune, 1_000_000)
 	for i := range haystack {
 		haystack[i] = letterRunes[rand.Intn(len(letterRunes))]

--- a/examples/simple_rule_match/main.go
+++ b/examples/simple_rule_match/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/bradleyjkemp/sigma-go"
+	"github.com/bradleyjkemp/sigma-go/evaluator"
+)
+
+func main() {
+	//
+	// Load the Sigma rule (simplified representation here)
+	sigmaRule := `
+title: Okta Application Modified or Deleted
+id: 7899144b-e416-4c28-b0b5-ab8f9e0a541d
+status: test
+description: Detects when an application is modified or deleted.
+references:
+  - https://developer.okta.com/docs/reference/api/system-log/
+  - https://developer.okta.com/docs/reference/api/event-types/
+author: Austin Songer @austinsonger
+date: 2021/09/12
+modified: 2022/10/09
+tags:
+  - attack.impact
+logsource:
+  product: okta
+  service: okta
+detection:
+  selection:
+    eventtype:
+      - application.lifecycle.update
+      - application.lifecycle.delete
+  condition: selection
+falsepositives:
+  - Unknown
+
+level: medium
+
+  `
+	// Parse the Sigma rule
+	rule, err := sigma.ParseRule([]byte(sigmaRule))
+	if err != nil {
+		log.Fatalf("Failed to parse Sigma rule: %v", err)
+	}
+
+	// Query Okta logs (simplified, you'll need to implement actual API querying)
+	oktaEvents := queryOktaLogs()
+
+	// Rules need to be wrapped in an evaluator.
+	// This is also where (if needed) you provide functions implementing the count, max, etc. aggregation functions
+	e := evaluator.ForRule(rule)
+
+	// Evaluate each Okta event against the Sigma rule
+	for _, event := range oktaEvents {
+		matches, err := e.Matches(context.Background(), event)
+		if err != nil {
+			log.Printf("Error evaluating rule: %v", err)
+			continue
+		}
+		if matches.Match {
+			fmt.Println("Detected an application modification or deletion event:", event)
+			// Implement your detection handling logic here (e.g., alerting)
+		}
+	}
+}
+
+// queryOktaLogs simulates querying Okta logs. Replace with actual API calls.
+func queryOktaLogs() []map[string]interface{} {
+	// This is a simplified example. You should replace this function with one
+	// that makes HTTP requests to Okta's system log API and parses the response.
+	// See https://developer.okta.com/docs/reference/api/system-log/ for details.
+	return []map[string]interface{}{
+		{"eventtype": "application.lifecycle.update", "details": "Application updated"},
+		// Add more events as needed
+	}
+}

--- a/testdata/TestParseRule-UpstreamSigmaRule
+++ b/testdata/TestParseRule-UpstreamSigmaRule
@@ -1,0 +1,452 @@
+(sigma.Rule) {
+  Title: (string) (len=34) "Potential XCSSET Malware Infection",
+  Logsource: (sigma.Logsource) {
+    Category: (string) (len=16) "process_creation",
+    Product: (string) (len=5) "macos",
+    Service: (string) "",
+    Definition: (string) "",
+    AdditionalFields: (map[string]interface {}) <nil>
+  },
+  Detection: (sigma.Detection) {
+    Searches: (map[string]sigma.Search) (len=5) {
+      (string) (len=16) "selection_1_curl": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=16) "selection_1_curl",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 16,
+          Column: (int) 3
+        }),
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=3) {
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "ParentImage|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 17,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "ParentImage",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=5) "/bash"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=14) "Image|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 18,
+                Column: (int) 5
+              }),
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=5) "/curl"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "CommandLine|contains",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 19,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]interface {}) (len=3) {
+                (string) (len=12) "/sys/log.php",
+                (string) (len=15) "/sys/prepod.php",
+                (string) (len=13) "/sys/bin/Pods"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=17) "selection_1_https": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=17) "selection_1_https",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 23,
+          Column: (int) 3
+        }),
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=1) {
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "CommandLine|contains",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 24,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "contains"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=8) "https://"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=17) "selection_other_1": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=17) "selection_other_1",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 25,
+          Column: (int) 3
+        }),
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=3) {
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "ParentImage|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 26,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "ParentImage",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=5) "/bash"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=14) "Image|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 27,
+                Column: (int) 5
+              }),
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=11) "/osacompile"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=24) "CommandLine|contains|all",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 28,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]interface {}) (len=2) {
+                (string) (len=7) "/Users/",
+                (string) (len=26) "/Library/Group Containers/"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=17) "selection_other_2": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=17) "selection_other_2",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 31,
+          Column: (int) 3
+        }),
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=3) {
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=20) "ParentImage|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 32,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "ParentImage",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=5) "/bash"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=14) "Image|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 33,
+                Column: (int) 5
+              }),
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=7) "/plutil"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=24) "CommandLine|contains|all",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 34,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]interface {}) (len=3) {
+                (string) (len=11) "LSUIElement",
+                (string) (len=7) "/Users/",
+                (string) (len=26) "/Library/Group Containers/"
+              }
+            }
+          }
+        }
+      },
+      (string) (len=37) "selection_other_again_test_one_more_3": (sigma.Search) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=37) "selection_other_again_test_one_more_3",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 38,
+          Column: (int) 3
+        }),
+        Keywords: ([]string) <nil>,
+        EventMatchers: ([]sigma.EventMatcher) (len=1) {
+          (sigma.EventMatcher) (len=2) {
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=14) "Image|endswith",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 39,
+                Column: (int) 5
+              }),
+              Field: (string) (len=5) "Image",
+              Modifiers: ([]string) (len=1) {
+                (string) (len=8) "endswith"
+              },
+              Values: ([]interface {}) (len=1) {
+                (string) (len=4) "/zip"
+              }
+            },
+            (sigma.FieldMatcher) {
+              node: (*yaml.Node)({
+                Kind: (yaml.Kind) 8,
+                Style: (yaml.Style) 0,
+                Tag: (string) (len=5) "!!str",
+                Value: (string) (len=24) "CommandLine|contains|all",
+                Anchor: (string) "",
+                Alias: (*yaml.Node)(<nil>),
+                Content: ([]*yaml.Node) <nil>,
+                HeadComment: (string) "",
+                LineComment: (string) "",
+                FootComment: (string) "",
+                Line: (int) 40,
+                Column: (int) 5
+              }),
+              Field: (string) (len=11) "CommandLine",
+              Modifiers: ([]string) (len=2) {
+                (string) (len=8) "contains",
+                (string) (len=3) "all"
+              },
+              Values: ([]interface {}) (len=3) {
+                (string) (len=2) "-r",
+                (string) (len=7) "/Users/",
+                (string) (len=26) "/Library/Group Containers/"
+              }
+            }
+          }
+        }
+      }
+    },
+    Conditions: (sigma.Conditions) (len=1) {
+      (sigma.Condition) {
+        node: (*yaml.Node)({
+          Kind: (yaml.Kind) 8,
+          Style: (yaml.Style) 0,
+          Tag: (string) (len=5) "!!str",
+          Value: (string) (len=57) "all of selection_1_* or 1 of selection_other_again_test_*",
+          Anchor: (string) "",
+          Alias: (*yaml.Node)(<nil>),
+          Content: ([]*yaml.Node) <nil>,
+          HeadComment: (string) "",
+          LineComment: (string) "",
+          FootComment: (string) "",
+          Line: (int) 44,
+          Column: (int) 14
+        }),
+        Search: (sigma.Or) (len=2) {
+          (sigma.AllOfPattern) {
+            Pattern: (string) (len=13) "selection_1_*"
+          },
+          (sigma.OneOfPattern) {
+            Pattern: (string) (len=28) "selection_other_again_test_*"
+          }
+        },
+        Aggregation: (sigma.AggregationExpr) <nil>
+      }
+    },
+    Timeframe: (time.Duration) 0s
+  },
+  ID: (string) (len=36) "47d65ac0-c06f-4ba2-a2e3-d263139d0f51",
+  Related: ([]sigma.RelatedRule) <nil>,
+  Status: (string) (len=4) "test",
+  Description: (string) (len=263) "Identifies the execution traces of the XCSSET malware. XCSSET is a macOS trojan that primarily spreads via Xcode projects and maliciously modifies applications. Infected users are also vulnerable to having their credentials, accounts, and other vital data stolen.",
+  Author: (string) (len=32) "Tim Rauch (rule), Elastic (idea)",
+  Level: (string) (len=6) "medium",
+  References: ([]string) (len=2) {
+    (string) (len=166) "https://github.com/elastic/protections-artifacts/commit/746086721fd385d9f5c6647cada1788db4aea95f#diff-f5deb07688e1a8dec9530bc3071967b2da5c16b482e671812b864c37beb28f08",
+    (string) (len=59) "https://malpedia.caad.fkie.fraunhofer.de/details/osx.xcsset"
+  },
+  Tags: ([]string) (len=1) {
+    (string) (len=26) "attack.command_and_control"
+  },
+  AdditionalFields: (map[string]interface {}) (len=2) {
+    (string) (len=4) "date": (string) (len=10) "2022/10/17",
+    (string) (len=14) "falsepositives": ([]interface {}) (len=1) {
+      (string) (len=7) "Unknown"
+    }
+  }
+}

--- a/testdata/UpstreamSigmaRule.rule.yml
+++ b/testdata/UpstreamSigmaRule.rule.yml
@@ -1,0 +1,47 @@
+title: Potential XCSSET Malware Infection
+id: 47d65ac0-c06f-4ba2-a2e3-d263139d0f51
+status: test
+description: Identifies the execution traces of the XCSSET malware. XCSSET is a macOS trojan that primarily spreads via Xcode projects and maliciously modifies applications. Infected users are also vulnerable to having their credentials, accounts, and other vital data stolen.
+references:
+  - https://github.com/elastic/protections-artifacts/commit/746086721fd385d9f5c6647cada1788db4aea95f#diff-f5deb07688e1a8dec9530bc3071967b2da5c16b482e671812b864c37beb28f08
+  - https://malpedia.caad.fkie.fraunhofer.de/details/osx.xcsset
+author: Tim Rauch (rule), Elastic (idea)
+date: 2022/10/17
+tags:
+  - attack.command_and_control
+logsource:
+  category: process_creation
+  product: macos
+detection:
+  selection_1_curl:
+    ParentImage|endswith: "/bash"
+    Image|endswith: "/curl"
+    CommandLine|contains:
+      - "/sys/log.php"
+      - "/sys/prepod.php"
+      - "/sys/bin/Pods"
+  selection_1_https:
+    CommandLine|contains: "https://"
+  selection_other_1:
+    ParentImage|endswith: "/bash"
+    Image|endswith: "/osacompile"
+    CommandLine|contains|all:
+      - "/Users/"
+      - "/Library/Group Containers/"
+  selection_other_2:
+    ParentImage|endswith: "/bash"
+    Image|endswith: "/plutil"
+    CommandLine|contains|all:
+      - "LSUIElement"
+      - "/Users/"
+      - "/Library/Group Containers/"
+  selection_other_again_test_one_more_3:
+    Image|endswith: "/zip"
+    CommandLine|contains|all:
+      - "-r"
+      - "/Users/"
+      - "/Library/Group Containers/"
+  condition: all of selection_1_* or 1 of selection_other_again_test_*
+falsepositives:
+  - Unknown
+level: medium


### PR DESCRIPTION
While testing the upstreams rules for SigmaHQ, conditions with multiple underscores failed the regex parser with 

```
Error parsing rule 1:20: invalid token '*'
Found error 1:20: invalid token '*'
```

Specifically this condition from upstream

```
  condition: "all of selection_1_* or 1 of selection_other_*"
```

The following regex didn't properly catch when multiple underscores where used

`|(?P<SearchIdentifierPattern>\*?[a-zA-Z_]+\*[a-zA-Z0-9_*]*)`

![Screenshot 2024-02-28 at 1 58 17 PM](https://github.com/bradleyjkemp/sigma-go/assets/3443378/7375402d-30fa-4ba2-807a-df67a22095ca)

But this new one now allows for the match to have any number of underscores before defining the regex pattern. 



### Additional Example

Added an examples directory as the provided example in the README.md was a little vague with sigma.Evalutator (which didn't work for me), and changed it to a working example as well. 