### PR TITLE
fix for issue #42

### DIFF
--- a/evaluator/modifiers/modifiers_test.go
+++ b/evaluator/modifiers/modifiers_test.go
@@ -8,27 +8,40 @@ import (
 
 func Test_compareNumeric(t *testing.T) {
 	tests := []struct {
-		left    interface{}
-		right   interface{}
-		wantGt  bool
-		wantGte bool
-		wantLt  bool
-		wantLte bool
+		left       interface{}
+		right      interface{}
+		wantGt     bool
+		wantGte    bool
+		wantLt     bool
+		wantLte    bool
+		shouldFail bool
 	}{
-		{1, 2, false, false, true, true},
-		{1.1, 1.2, false, false, true, true},
-		{1, 1.2, false, false, true, true},
-		{1.1, 2, false, false, true, true},
-		{1, "2", false, false, true, true},
-		{"1.1", 1.2, false, false, true, true},
-		{"1.1", 1.1, false, true, false, true},
+		{1, 2, false, false, true, true, false},
+		{1.1, 1.2, false, false, true, true, false},
+		{1, 1.2, false, false, true, true, false},
+		{1.1, 2, false, false, true, true, false},
+		{1, "2", false, false, true, true, false},
+		{"1.1", 1.2, false, false, true, true, false},
+		{"1.1", 1.1, false, true, false, true, false},
+
+		// The function panics if it's interfaces are nil, this happens if it doesn't find the field in the event and it's compared to a int or float
+		{nil, 2, true, false, false, false, true},
+		{nil, nil, true, false, false, false, true},
+		{2, nil, true, false, false, false, true},
+		// If we pass anything (like an ip address) other than an int or float, the functions recurses until it stack overflows
+		{"127.0.0.1", "127.0.0.1", true, false, false, false, true},
+		{"127.0.0.1", 0.2, true, false, false, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s_%s", tt.left, tt.right), func(t *testing.T) {
 			gotGt, gotGte, gotLt, gotLte, err := compareNumeric(tt.left, tt.right)
 			if err != nil {
-				t.Errorf("compareNumeric() error = %v", err)
-				return
+				if !tt.shouldFail {
+					t.Errorf("compareNumeric() error = %v", err)
+					return
+				} else {
+					return
+				}
 			}
 			if gotGt != tt.wantGt {
 				t.Errorf("compareNumeric() gotGt = %v, want %v", gotGt, tt.wantGt)


### PR DESCRIPTION
fixes for a panic if a nil interface is passed to coerceNumeric and a stack overflow if the interface is not unmarshaled as numeric type by yaml. Should fix #42 