### PR TITLE
fix bug: get event value with key

### DIFF
--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/bradleyjkemp/sigma-go"
 	"github.com/bradleyjkemp/sigma-go/evaluator/modifiers"
@@ -87,21 +86,58 @@ type Result struct {
 // Event should be some form a map[string]interface{} or map[string]string
 type Event interface{}
 
-func getNestedValue(data map[string]interface{}, path string) interface{} {
-	parts := strings.Split(path, ".")
-	current := data
+func flattenJSON(data interface{}, prefix string, result map[string]interface{}) {
+	switch v := data.(type) {
+	case map[string]interface{}:
+		for k, val := range v {
+			newKey := k
+			if prefix != "" {
+				newKey = prefix + "." + k
+			}
+			flattenJSON(val, newKey, result)
+		}
 
-	for i, part := range parts {
-		if i == len(parts)-1 {
-			return current[part]
+	case []interface{}:
+		if len(v) == 0 {
+			result[prefix] = v
+			return
 		}
-		next, ok := current[part].(map[string]interface{})
-		if !ok {
-			return nil
+
+		if _, isMap := v[0].(map[string]interface{}); isMap {
+			fieldsMap := make(map[string][]interface{})
+			for _, item := range v {
+				if mapItem, ok := item.(map[string]interface{}); ok {
+					for k, val := range mapItem {
+						key := prefix + "." + k
+						fieldsMap[key] = append(fieldsMap[key], val)
+					}
+				}
+			}
+			for k, val := range fieldsMap {
+				result[k] = val
+			}
+		} else {
+			result[prefix] = v
 		}
-		current = next
+
+	case string:
+		switch v {
+		case "False", "false":
+			result[prefix] = false
+		case "True", "true":
+			result[prefix] = true
+		default:
+			result[prefix] = v
+		}
+	default:
+		result[prefix] = v
 	}
-	return nil
+}
+
+func getNestedValue(data map[string]interface{}, path string) interface{} {
+	result := make(map[string]interface{})
+	flattenJSON(data, "", result)
+	return result[path]
 }
 
 func eventValue(e Event, key string) interface{} {

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/bradleyjkemp/sigma-go"
 	"github.com/bradleyjkemp/sigma-go/evaluator/modifiers"
 )
@@ -85,12 +87,25 @@ type Result struct {
 // Event should be some form a map[string]interface{} or map[string]string
 type Event interface{}
 
+func getNestedValue(data map[string]interface{}, path string) interface{} {
+	parts := strings.Split(path, ".")
+	current := data
+
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			return current[part]
+		}
+		current = current[part].(map[string]interface{})
+	}
+	return nil
+}
+
 func eventValue(e Event, key string) interface{} {
 	switch evt := e.(type) {
 	case map[string]string:
 		return evt[key]
 	case map[string]interface{}:
-		return evt[key]
+		return getNestedValue(evt, key)
 	default:
 		return ""
 	}

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -105,7 +105,12 @@ func eventValue(e Event, key string) interface{} {
 	case map[string]string:
 		return evt[key]
 	case map[string]interface{}:
-		return getNestedValue(evt, key)
+		result := getNestedValue(evt, key)
+		if result != nil {
+			return getNestedValue(evt, key)
+		} else {
+			return ""
+		}
 	default:
 		return ""
 	}

--- a/evaluator/evaluate.go
+++ b/evaluator/evaluate.go
@@ -95,7 +95,11 @@ func getNestedValue(data map[string]interface{}, path string) interface{} {
 		if i == len(parts)-1 {
 			return current[part]
 		}
-		current = current[part].(map[string]interface{})
+		next, ok := current[part].(map[string]interface{})
+		if !ok {
+			return nil
+		}
+		current = next
 	}
 	return nil
 }
@@ -105,12 +109,7 @@ func eventValue(e Event, key string) interface{} {
 	case map[string]string:
 		return evt[key]
 	case map[string]interface{}:
-		result := getNestedValue(evt, key)
-		if result != nil {
-			return getNestedValue(evt, key)
-		} else {
-			return ""
-		}
+		return getNestedValue(evt, key)
 	default:
 		return ""
 	}

--- a/evaluator/evaluate_search.go
+++ b/evaluator/evaluate_search.go
@@ -125,9 +125,6 @@ eventMatcher:
 			if err != nil {
 				return false, err
 			}
-			if values == nil {
-				return false, nil
-			}
 			if !rule.matcherMatchesValues(matcherValues, comparator, allValuesMustMatch, values) {
 				// this field didn't match so the overall matcher doesn't match, try the next EventMatcher
 				continue eventMatcher

--- a/evaluator/evaluate_search.go
+++ b/evaluator/evaluate_search.go
@@ -175,7 +175,8 @@ func (rule *RuleEvaluator) GetFieldValuesFromEvent(field string, event Event) ([
 	var actualValues []interface{}
 	if len(rule.fieldmappings[field]) == 0 {
 		// No FieldMapping exists so use the name directly from the rule
-		actualValues = []interface{}{eventValue(event, field)}
+		// actualValues = []interface{}{eventValue(event, field)}
+		actualValues = toGenericSlice(eventValue(event, field))
 	} else {
 		// FieldMapping does exist so check each of the possible mapped names instead of the name from the rule
 		for _, mapping := range rule.fieldmappings[field] {

--- a/evaluator/evaluate_search.go
+++ b/evaluator/evaluate_search.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/PaesslerAG/jsonpath"
-	"github.com/bradleyjkemp/sigma-go"
-	"github.com/bradleyjkemp/sigma-go/evaluator/modifiers"
 	"path"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/bradleyjkemp/sigma-go"
+	"github.com/bradleyjkemp/sigma-go/evaluator/modifiers"
 )
 
 func (rule RuleEvaluator) evaluateSearchExpression(search sigma.SearchExpr, searchResults func(string) bool) bool {
@@ -123,6 +124,9 @@ eventMatcher:
 			values, err := rule.GetFieldValuesFromEvent(fieldMatcher.Field, event)
 			if err != nil {
 				return false, err
+			}
+			if values == nil {
+				return false, nil
 			}
 			if !rule.matcherMatchesValues(matcherValues, comparator, allValuesMustMatch, values) {
 				// this field didn't match so the overall matcher doesn't match, try the next EventMatcher


### PR DESCRIPTION
In function `eventValue` in `evaluator/evaluate.go`, if type `event` is `interface{}`, function can't return true value. Example:
```
- Event:
{
    "log": {
      "source": {
        "name": "aws",
        "product": "cloudtrail",
        "vendor": "aws"
      }
    }
}

- Key: "log.source.name"
- Reality return value of function: null
- True return value: "aws"
```
To fix this bug, need to flatten event to be able to get value by key string. Example:
```
- Event:
{
    "log": {
      "source": {
        "name": "aws",
        "product": "cloudtrail",
        "vendor": "aws"
      }
    }
}
- Flatten event:
{
  "log.source.name": "aws",
  "log.source.product": "cloudtrail",
  "log.source.vendor": "aws"
}
```
And of course we also need to unify the output of the `eventValue` function as an array by using `toGenericSlice`, to avoid the case where the return value of the `eventValue` function is an array. Example:

```
- Event:
{
  "log": [
    {
      "key": 1,
      "value": "a",
    },
    {
      "key": 2,
      "value": "b",
    }
  ],
  "temp": "abc"
}
- Flatten event:
{
  "log.key": [1, 2],
  "log.value": ["a", "b"]
}

With "[]interface{}{eventValue(event, field)}" :
- Key: "log.key"
- Value: error

- Key: "temp"
- Value: ["temp"]

With "toGenericSlice(eventValue(event, field))" :
- Key: "log.key"
- Value: [1,2]

- Key: "temp"
- Value: ["temp"]
```