### PR TITLE
[BUGFIX] Rules with Timeframes fail to parse correctly

### DIFF
--- a/rule_parser.go
+++ b/rule_parser.go
@@ -63,7 +63,7 @@ func (d *Detection) UnmarshalYAML(node *yaml.Node) error {
 				return err
 			}
 		case "timeframe":
-			if err := node.Decode(&d.Timeframe); err != nil {
+			if err := value.Decode(&d.Timeframe); err != nil {
 				return err
 			}
 		default:


### PR DESCRIPTION
When attempting to unmarshal a rule containing a timeframe key, the entire rule object was being unmarshaled into a time.Duration - causing a failure: 

```
 line 14: cannot unmarshal !!map into time.Duration
```

PR updates the unmarshal call to act on the value, rather than the entire rule document itself. 